### PR TITLE
Update scores.default.R

### DIFF
--- a/R/scores.default.R
+++ b/R/scores.default.R
@@ -42,6 +42,7 @@
         ## as.matrix() changes 1-row scores into 1-col matrix: this is
         ## a hack which may fail sometimes (but probably less often
         ## than without this hack):
+        if (!missing(choices))
         if (ncol(X) == 1 && nrow(X) == length(choices))
             X <- t(X)
     }


### PR DESCRIPTION
The modification allows one to work with univariate matrices (containing just one column) without the need to specify the choices argument. Now if x is numeric and contains just one column the scores.default function returns exactly the same x, without returns an error. This modification allows the use of the procrustes function with univariate matrices.
