### PR TITLE
nestednodf binary/weighted consistency

### DIFF
--- a/R/nestednodf.R
+++ b/R/nestednodf.R
@@ -1,5 +1,5 @@
 `nestednodf` <- 
-    function(comm, order = TRUE, weighted = FALSE) 
+    function(comm, order = TRUE, weighted = FALSE, wbinary = FALSE) 
 {
     bin.comm <- ifelse(comm > 0, 1, 0)
     rfill <- rowSums(bin.comm)
@@ -34,8 +34,12 @@
                 next
             if (weighted) {
                 second <- comm[j, ]
-                N.paired.rows[counter] <-
-                    sum(first - second > 0 & second > 0)/sum(second > 0)
+                if (!wbinary) 
+                    N.paired.rows[counter] <-
+                        sum(first - second > 0 & second > 0)/sum(second > 0)
+                else
+                    N.paired.rows[counter] <-
+                        sum(first - second >= 0 & second > 0)/sum(second > 0)
             }
             else {
                 N.paired.rows[counter] <-
@@ -52,8 +56,12 @@
                 next
             if (weighted) {
                 second <- comm[, j]
-                N.paired.cols[counter] <-
-                    sum(first - second > 0 & second > 0)/sum(second > 0)
+                if (!wbinary)
+                    N.paired.cols[counter] <-
+                        sum(first - second > 0 & second > 0)/sum(second > 0)
+                else
+                    N.paired.cols[counter] <-
+                        sum(first - second >= 0 & second > 0)/sum(second > 0)
             }
             else {
                 N.paired.cols[counter] <-

--- a/inst/ChangeLog
+++ b/inst/ChangeLog
@@ -159,6 +159,14 @@ Version 2.1-40 (closed December 12, 2013)
 	sure. Also fixed handling of tied values in assessing the P-values
 	in vectorfit.
 
+	* nestednodf: vegan 2.1-36 (release 2.0-10) changed the function
+	so that weighted analysis of binary data was equal to unweighted
+	binary analysis, but this broke consinstency with the original
+	software and publication by Almeida-Neto & Ulrich. The fix was now
+	made optional, and the default is to follow published method by
+	adding argument 'wbinary' (defaults FALSE). Based on the
+	suggestion by Matt Barbour in GitHub.
+
 	* ordispider: can now use spatial medians as centres instead of
 	the default centroids. The kind of centre is defined by new
 	argument 'spiders'.

--- a/man/nestedtemp.Rd
+++ b/man/nestedtemp.Rd
@@ -24,7 +24,7 @@ nestedchecker(comm)
 nestedn0(comm)
 nesteddisc(comm, niter = 200)
 nestedtemp(comm, ...)
-nestednodf(comm, order = TRUE, weighted = FALSE)
+nestednodf(comm, order = TRUE, weighted = FALSE, wbinary = FALSE)
 nestedbetasor(comm)
 nestedbetajac(comm)
 \method{plot}{nestedtemp}(x, kind = c("temperature", "incidence"),
@@ -43,6 +43,8 @@ nestedbetajac(comm)
     returned accordingly.}
   \item{order}{Order rows and columns by frequencies.}
   \item{weighted}{Use species abundances as weights of interactions.}
+  \item{wbinary}{Modify original method so that binary data give the same 
+    result in weighted and and unweighted analysis. }
   \item{\dots}{Other arguments to functions.}
 }
 
@@ -112,7 +114,14 @@ nestedbetajac(comm)
   al. 2008). With \code{weighted = TRUE}, the function finds the
   weighted version of the index (Almeida-Neto & Ulrich,
   2011). However, this requires quantitative null models for adequate
-  testing.
+  testing. Almeida-Neto & Ulrich (2011) say that you have positive
+  nestedness if values in the first row/column are higher than in the
+  second.  With this condition, weighted analysis of binary data will
+  always give zero nestedness. With argument \code{wbinary = TRUE},
+  equality of rows/colums also indicates nestedness, and binary data
+  will give identical results in weighted and unweighted analysis.
+  However, this can also influence the results of weighted analysis so
+  that the results may differ from Almeida-Neto & Ulrich (2011).
 
   Functions \code{nestedbetasor} and \code{nestedbetajac} find
   multiple-site dissimilarities and decompose these into components of


### PR DESCRIPTION
Issue #23 reverted earlier changes in nestenodf so that the function gives identical results to Ulrich's original software. However, now a weighted analysis of binary data will give zero nestedness. The suggested change makes choice optional between original and (what I see) improved analysis.
