### PR TITLE
Omit NA cases in 'groups' in ordiellipse, ordihull & ordispider

### DIFF
--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -34,7 +34,7 @@
     if (label)
         cntrs <- names <- NULL
     ## Remove NA scores
-    kk <- complete.cases(pts)
+    kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
         gr <- out[groups == is & kk]
         if (length(gr) > 1) {

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -30,7 +30,7 @@
     if (label)
         cntrs <- names <- NULL
     ## Remove NA scores
-    kk <- complete.cases(pts)
+    kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
         gr <- out[groups == is & kk]
         if (length(gr) > 1) {

--- a/R/ordispider.R
+++ b/R/ordispider.R
@@ -38,8 +38,8 @@
     inds <- names(table(groups))
     if (label) 
     cntrs <- names <- NULL
-    ## 'kk' removes NA scores
-    kk <- complete.cases(pts)
+    ## 'kk' removes NA scores and NA groups
+    kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
         gr <- out[groups == is & kk]
         if (length(gr)) {

--- a/inst/ChangeLog
+++ b/inst/ChangeLog
@@ -4,6 +4,11 @@ VEGAN DEVEL VERSIONS at http://r-forge.r-project.org/
 
 Version 2.1-41 (opened December 12, 2013)
 
+	* ordiellipse, ordihull, ordispider: can now handle (omit) NA
+	cases in 'groups'. They were able to omit to NA cases in scores,
+	but having NA in 'groups' triggered really cryptic error
+	messages. 
+
 	* adipart, multipart, hiersimu: it is now an error to provide
 	non-nested sampling hierarchy (used to be a warning).
 


### PR DESCRIPTION
Earlier NA were omitted in scores, but having NA in 'groups'
was an error with cryptic message.
