### PR TITLE
Explicit import of s() is needed in not-so-old mgcv

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -73,7 +73,8 @@ import(tcltk)
 importFrom(MASS, isoMDS, sammon, Shepard, mvrnorm)
 import(rgl)
 importFrom(cluster, daisy)
-importFrom(mgcv, gam)
+## 's' must be imported in mgcv < 1.8-0 (not needed later)
+importFrom(mgcv, gam, s)
 ## Registration of S3 methods defined in vegan
 # adipart: vegan
 S3method(adipart, default)


### PR DESCRIPTION
NAMESPACE upgrade (3dc3111, PR #28 in github) broke mgcv < 1.8-0:

Error in eval(expr, envir, enclos) : could not find function "s"
Execution halted

This can be fixed in two ways: adding dependence on mgcv (>= 1.8-0)
in DESCRIPTION, or with explicit import of s in NAMESPACE. mgcv
1.8-0 was released on 25-Jun-2014 so that it is pretty young, and
therefore this fix suggests editing NAMESPACE.
