### PR TITLE
permutest.betadisper: no. of permutations counted without observed stat

### DIFF
--- a/R/permutest.betadisper.R
+++ b/R/permutest.betadisper.R
@@ -130,7 +130,7 @@
         pairwise <- NULL
     }
 
-    retval <- cbind(mod.aov[, 1:4], c(nperm + 1, NA), c(pval, NA))
+    retval <- cbind(mod.aov[, 1:4], c(nperm, NA), c(pval, NA))
     dimnames(retval) <- list(c("Groups", "Residuals"),
                              c("Df", "Sum Sq", "Mean Sq", "F", "N.Perm",
                                "Pr(>F)"))


### PR DESCRIPTION
Although we put the observed value among permutations, the number
of permutations should be given without that observed statistic
(like done in all other vegan functions).

Now the output of of `example(permutest.betadisper)` reads:

``` coffee
Permutation test for homogeneity of multivariate dispersions
Permutation: free
Number of permutations: 99

Response: Distances
          Df  Sum Sq  Mean Sq      F N.Perm Pr(>F)  
Groups     1 0.07931 0.079306 4.6156    100   0.05 *
Residuals 22 0.37801 0.017182                       
```

We first give no. of perm as 99 in the header, and then as 100 in the table. The consistent way is to give the no. of permutations without observed value.

This is for @gavinsimpson to decide. 
