### PR TITLE
Add test statistic among permutations in permutest.betadisper

### DIFF
--- a/R/permutest.betadisper.R
+++ b/R/permutest.betadisper.R
@@ -122,8 +122,8 @@
             length(x$distances[group == z[1]]) +
                 length(x$distance[group == z[2]]) - 2})
         pairwise <- list(observed = 2 * pt(-abs(T0), df),
-                         permuted = apply(Tstats, 2,
-                         function(z) (sum(abs(z) >= abs(z[1])) + 1) / (length(z) + 1)))
+                         permuted = apply(rbind(T0, Tstats), 2,
+                         function(z) (sum(abs(z) >= abs(z[1]))) / (length(z))))
         names(pairwise$observed) <- names(pairwise$permuted) <-
             apply(combin, 2, paste, collapse = "-")
     } else {


### PR DESCRIPTION
Fixes bug introduced in a255767, where pairwise tests compared
permutations against wrong value of test statistic. Now we add
test statistic among permutations. Because this is done (= first
row of permutations is the test statistic), we also must omit the
+1 term in the numerator and denominator.

@gavinsimpson : I think this fixes the problems with pairwise
tests. Now the firs item really is `T0`, and since it really is
among permutations we also drop `+1`.
