### PR TITLE
fix a bug in calculation of p value in group pairwise permutation test

### DIFF
--- a/R/permutest.betadisper.R
+++ b/R/permutest.betadisper.R
@@ -121,9 +121,10 @@
         df <- apply(combin, 2, function(z) {
             length(x$distances[group == z[1]]) +
                 length(x$distance[group == z[2]]) - 2})
+        pairp <- (colSums(sweep(abs(Tstats), 2, abs(T0), '>=')) + 1) /
+            (NROW(Tstats) + 1)
         pairwise <- list(observed = 2 * pt(-abs(T0), df),
-                         permuted = apply(Tstats, 2,
-                         function(z) (sum(abs(z) >= abs(z[1])) + 1) / (length(z) + 1)))
+                         permuted = pairp)
         names(pairwise$observed) <- names(pairwise$permuted) <-
             apply(combin, 2, paste, collapse = "-")
     } else {


### PR DESCRIPTION
This bug was introduced in abb5b0b66bb207c2af24003532c1541b04543457 because I failed to correct the existing code for the fact that the observed test statistics `T0` were not physically _in_ the object used to compute the _p_-value as they had been previously.

@jarioksa proposed a simple fix in PR #48 whilst I was testing this alternative, which doesn't require growing the object containing the permuted _t_ statistics (`Tstats`) to include the observed, and avoids a loop over this object at the R level.
