### PR TITLE
Fix labelling envfit plots with a vector of labels

### DIFF
--- a/R/plot.envfit.R
+++ b/R/plot.envfit.R
@@ -21,7 +21,7 @@
                 stop("needs a list with both 'vectors' and 'factors' labels")
             ## need to handle the case where both sets of labels are NULL
             ## such as when used with the default interface and single x
-            ln <- sapply(labs, is.null)
+            ln <- !sapply(labs, is.null)
             if (ln["v"])
                 labs$v <- labels
             if (ln["f"])


### PR DESCRIPTION
Fixes bug report #74 at github.com: it was documented that you
do not need to use a list(vectors=, factors=) to relabel plotted
items if there is only one type of items (vectors or factors), but
you can use a single vector of new labels.
