### PR TITLE
Better fix than 83d3bf1 and cca3f27 for resetting labels in envfit

### DIFF
--- a/R/plot.envfit.R
+++ b/R/plot.envfit.R
@@ -17,15 +17,14 @@
         } else {
             ## input vector: either vectors or factors must be NULL,
             ## and the existing set of labels is replaced
-            if (!is.null(labs$v) && !is.null(labs$f))
+            if (!is.null(x$vectors) && !is.null(x$factors))
                 stop("needs a list with both 'vectors' and 'factors' labels")
             ## need to handle the case where both sets of labels are NULL
             ## such as when used with the default interface and single x
-            ln <- !sapply(labs, is.null)
-            if (ln["v"])
-                labs$v <- labels
-            if (ln["f"])
+            if (!is.null(x$factors))
                 labs$f <- labels
+            else
+                labs$v <- labels
         }
     }
     vect <- NULL


### PR DESCRIPTION
Previous fix only looked at the null of internal labels, but these
can be null because the item (vectors or factors) was missing, or
the item was there but names were missing. Fix cca3f27 failed
in the first case and 83d3bf1 in latter case. Now we check for
the existence of factors/vectors, and if only one them is present,
we reset its labels whether they existed or were null.
