### PR TITLE
Fix reconstruction of response matrix in CA (no CCA) for tolerance.cca

### DIFF
--- a/R/tolerance.cca.R
+++ b/R/tolerance.cca.R
@@ -32,7 +32,11 @@ tolerance.cca <- function(x, choices = 1:2,
         which <- "species"
     ## reconstruct species/response matrix Y - up to machine precision!
     partialFit <- ifelse(is.null(x$pCCA$Fit), 0, x$pCCA$Fit)
-    Y <- ((partialFit + x$CCA$Xbar) * sqrt(x$rowsum %o% x$colsum) +
+    if (is.null(x$CCA))
+        Xbar <- x$CA$Xbar
+    else
+        Xbar <- x$CCA$Xbar
+    Y <- ((partialFit + Xbar) * sqrt(x$rowsum %o% x$colsum) +
           x$rowsum %o% x$colsum) * x$grand.total
     which <- match.arg(which)
     siteScrTypes <- if(is.null(x$CCA)){ "sites" } else {"lc"}


### PR DESCRIPTION
The function failed when it tried to reconstruct the data from the result of **un**constrained ordination. This is a direct fix of issue #77 
