### PR TITLE
varpart plot: new 4-part plot and colour scheme

### DIFF
--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -9,12 +9,15 @@
             bg <- rep(bg, length.out = parts)
     }
     cp <- switch(parts,
-                 c(0,0),
-                 c(0,0, 1,0),
-                 c(0,0, 1,0, 0.5, -sqrt(3/4)),
-                 c(NA,NA)
+                 matrix(c(0,0), ncol=2, byrow=TRUE),
+                 matrix(c(0,0, 1,0), ncol=2, byrow=TRUE),
+                 matrix(c(0,0, 1,0, 0.5, -sqrt(3/4)), ncol=2, byrow=TRUE),
+                 structure(
+                     c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0, 0.7, 0.7,
+                       0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7, 0, 0.3, 0.4,
+                       -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0, -0.7, -0.4),
+                     .Dim = c(15L, 2L))
                  )
-    cp <- matrix(cp, ncol=2, byrow=TRUE)
     if (parts < 4) {
         xlim <- range(cp[,1] + c(-rad, rad))
         ylim <- range(cp[,2] + c(-rad, rad))
@@ -57,11 +60,7 @@
            text(rbind(cp[1,], colMeans(cp), cp[2,]), labels[-nlabs], ...),
            text(rbind(cp, colMeans(cp[1:2,]), colMeans(cp[2:3,]),
                       colMeans(cp[c(1,3),]), colMeans(cp)), labels[-nlabs], ...),
-           text(structure(c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0,
-                            0.7, 0.7, 0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7,
-                            0, 0.3, 0.4, -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0,
-                            -0.7, -0.4), .Dim = c(15L, 2L)),
-                labels[-nlabs], ...)
+           text(cp, labels[-nlabs], ...)
            )
     xy <- par("usr")
     text(xy[2] - 0.05*diff(xy[1:2]), xy[3] + 0.05*diff(xy[3:4]),

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -6,18 +6,40 @@ function(parts = 2, labels, ...)
                  c(0,0),
                  c(0,0, 1,0),
                  c(0,0, 1,0, 0.5, -sqrt(3/4)),
-                 c(-0.5,0.3, 0.5, 0.3, 0, -sqrt(3/4)+0.3)
+                 c(NA,NA)
                  )
     cp <- matrix(cp, ncol=2, byrow=TRUE)
+    if (parts < 4) {
+        xlim <- range(cp[,1] + c(-rad, rad))
+        ylim <- range(cp[,2] + c(-rad, rad))
+    } else {
+        xlim <- c(-1.7, 1.7)
+        ylim <- c(-1.7, 1.1)
+    }
     plot(cp, axes=FALSE, xlab="", ylab="", asp=1, type="n", 
-         xlim = (range(cp[,1]) + c(-rad, rad)),
-         ylim = (range(cp[,2]) + c(-rad, rad)))
+         xlim = xlim, ylim = ylim)
     box()
-    symbols(cp, circles = rep(rad, min(parts,3)), inches = FALSE, add=TRUE, ...)
-    if (parts == 4) {
-        symbols(0, 0.2, rectangles=cbind(1, 0.5), inches=FALSE, add=TRUE, ...)
-        symbols(sqrt(1/2), -sqrt(3/4)+0.2, rectangles=cbind(0.5,0.3),
-                inches=FALSE, add=TRUE, ...)
+    if (parts < 4) 
+        symbols(cp, circles = rep(rad, min(parts,3)), inches = FALSE,
+                add=TRUE, ...)
+    else {
+        ## Draw ellipses with veganCovEllipse. Supply 2x2
+        ## matrix(c(d,a,a,d), 2, 2) which defines an ellipse of
+        ## semi-major axis length sqrt(d+a) semi-minor axis sqrt(d-a).
+        d <- 1
+        a <- 1/sqrt(2)
+        ## Small ellipses X2, X3 at the centroid
+        e2 <- veganCovEllipse(matrix(c(d,-a,-a,d), 2, 2))
+        e3 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2))
+        ## wider ellipses X1, X4 at sides going through the centroid
+        L <- d+a
+        W <- (sqrt(L) - sqrt(d-a))^2
+        d <- (L+W)/2
+        a <- (L-W)/2
+        cnt <- sqrt(W/2)
+        e1 <- veganCovEllipse(matrix(c(d,-a,-a,d), 2, 2), c(-cnt, -cnt))
+        e4 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2), c( cnt, -cnt))
+        polygon(rbind(e1,NA,e2,NA,e3,NA,e4), ...)
     }
     nlabs <- switch(parts, 2, 4, 8, 16)
     if (missing(labels))
@@ -29,14 +51,10 @@ function(parts = 2, labels, ...)
            text(rbind(cp[1,], colMeans(cp), cp[2,]), labels[-nlabs], ...),
            text(rbind(cp, colMeans(cp[1:2,]), colMeans(cp[2:3,]),
                       colMeans(cp[c(1,3),]), colMeans(cp)), labels[-nlabs], ...),
-           text(rbind(1.4*cp, c(0.8, -sqrt(3/4)+0.2),
-                      colMeans(cp[1:2,]) + c(0,0.25),
-                      colMeans(cp[2:3,]), colMeans(cp[c(1,3),]),
-                      cp[1,] + c(0.1,0), cp[2,] -c(0.1,0),
-                      c(0.6, -sqrt(3/4)+0.2), colMeans(cp[1:2,]),
-                      colMeans(cp)-c(0,0.12), colMeans(cp[2:3,]) + c(0,0.14),
-                      colMeans(cp[c(1,3),]) + c(0, 0.14),
-                      colMeans(cp) + c(0,0.08)),
+           text(structure(c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0,
+                            0.7, 0.7, 0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7,
+                            0, 0.3, 0.4, -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0,
+                            -0.7, -0.4), .Dim = c(15L, 2L)),
                 labels[-nlabs], ...)
            )
     xy <- par("usr")

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,17 +1,6 @@
-showvarpartsX <-
+`showvarparts` <-
     function(parts = 2, labels, bg = NULL, alpha=63, ...)
 {
-### Internal function
-veganCovEllipse <-    
-function (cov, center = c(0, 0), scale = 1, npoints = 100) 
-# Call this function as    vegan:::veganCovEllipse
-{
-    theta <- (0:npoints) * 2 * pi/npoints
-    Circle <- cbind(cos(theta), sin(theta))
-    t(center + scale * t(Circle %*% chol(cov)))
-}
-### End internal function
-
     rad <- 0.725
     ## transparent fill colours
     if (!is.null(bg)) {

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,7 +1,10 @@
 `showvarparts` <-
-    function(parts = 2, labels, bg = NULL, alpha=63, Xnames=c("X1","X2","X3","X4"), cex.main=1.2, ...)
+    function(parts, labels, bg = NULL, alpha=63, Xnames, cex.main=1.2, ...)
 {
     rad <- 0.725
+    ## Default names
+    if (missing(Xnames))
+        Xnames <- paste("X", seq_len(parts), sep="")
     ## transparent fill colours
     if (!is.null(bg)) {
         bg <- rgb(t(col2rgb(bg)), alpha = alpha, maxColorValue = 255)

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -19,8 +19,8 @@
                      .Dim = c(15L, 2L))
                  )
     if (parts < 4) {
-        xlim <- range(cp[,1] + c(-rad, rad))
-        ylim <- range(cp[,2] + c(-rad, rad))
+        xlim <- range(cp[,1]) + c(-rad, rad)
+        ylim <- range(cp[,2]) + c(-rad, rad)
     } else {
         xlim <- c(-1.7, 1.7)
         ylim <- c(-1.7, 1.1)

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,17 +1,6 @@
-showvarpartsX <-
+`showvarparts` <-
     function(parts = 2, labels, bg = NULL, alpha=63, Xnames=c("X1","X2","X3","X4"), cex.main=1.2, ...)
 {
-### Internal function
-veganCovEllipse <-    
-function (cov, center = c(0, 0), scale = 1, npoints = 100) 
-# Call this function as    vegan:::veganCovEllipse
-{
-    theta <- (0:npoints) * 2 * pi/npoints
-    Circle <- cbind(cos(theta), sin(theta))
-    t(center + scale * t(Circle %*% chol(cov)))
-}
-### End internal function
-
     rad <- 0.725
     ## transparent fill colours
     if (!is.null(bg)) {
@@ -22,15 +11,15 @@ function (cov, center = c(0, 0), scale = 1, npoints = 100)
     ## centroids of circles (parts < 4) or individual fractions (parts
     ## == 4)
     cp <- switch(parts,
-        matrix(c(0,0), ncol=2, byrow=TRUE),
-        matrix(c(0,0, 1,0), ncol=2, byrow=TRUE),
-        matrix(c(0,0, 1,0, 0.5, -sqrt(3/4)), ncol=2, byrow=TRUE),
-        structure(
-            c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0, 0.7, 0.7,
-            0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7, 0, 0.3, 0.4,
-            -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0, -0.7, -0.4),
-            .Dim = c(15L, 2L))
-        )
+                 matrix(c(0,0), ncol=2, byrow=TRUE),
+                 matrix(c(0,0, 1,0), ncol=2, byrow=TRUE),
+                 matrix(c(0,0, 1,0, 0.5, -sqrt(3/4)), ncol=2, byrow=TRUE),
+                 structure(
+                     c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0, 0.7, 0.7,
+                       0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7, 0, 0.3, 0.4,
+                       -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0, -0.7, -0.4),
+                     .Dim = c(15L, 2L))
+                 )
     ## plot limits
     if (parts < 4) {
         xlim <- range(cp[,1]) + c(-rad, rad)
@@ -46,12 +35,12 @@ function (cov, center = c(0, 0), scale = 1, npoints = 100)
     if (parts < 4) {
         symbols(cp, circles = rep(rad, min(parts,3)), inches = FALSE,
                 add=TRUE, bg = bg, ...)
-        # Explanatory data set names added by PL
+        ## Explanatory data set names added by PL
         if(parts==2) {
-        	pos.names = matrix(c(-0.65,1.65,0.65,0.65),2,2)
-        	} else if(parts==3) {
-        	pos.names = matrix(c(-0.65,1.65,-0.16,0.65,0.65,-1.5),3,2)
-        	}
+            pos.names = matrix(c(-0.65,1.65,0.65,0.65),2,2)
+        } else if(parts==3) {
+            pos.names = matrix(c(-0.65,1.65,-0.16,0.65,0.65,-1.5),3,2)
+        }
         text(pos.names,labels=Xnames[1:parts], cex=cex.main)
     } else {
         ## Draw ellipses with veganCovEllipse. Supply 2x2
@@ -71,7 +60,7 @@ function (cov, center = c(0, 0), scale = 1, npoints = 100)
         e1 <- veganCovEllipse(matrix(c(d,-a,-a,d), 2, 2), c(-cnt, -cnt))
         e4 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2), c( cnt, -cnt))
         polygon(rbind(e1,NA,e2,NA,e3,NA,e4), col = bg, ...)
-        # Explanatory data set names added by PL
+        ## Explanatory data set names added by PL
         pos.names = matrix(c(-1.62,-1.10,1.10,1.62,0.54,1.00,1.00,0.54),4,2)
         text(pos.names,labels=Xnames[1:4], cex=cex.main)
     }

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,7 +1,13 @@
-"showvarparts" <-
-function(parts = 2, labels, ...)
+`showvarparts` <-
+    function(parts = 2, labels, bg = NULL, alpha=63, ...)
 {
     rad <- 0.725
+    ## transparent fill colours
+    if (!is.null(bg)) {
+        bg <- rgb(t(col2rgb(bg)), alpha = alpha, maxColorValue = 255)
+        if (length(bg) < parts)
+            bg <- rep(bg, length.out = parts)
+    }
     cp <- switch(parts,
                  c(0,0),
                  c(0,0, 1,0),
@@ -21,7 +27,7 @@ function(parts = 2, labels, ...)
     box()
     if (parts < 4) 
         symbols(cp, circles = rep(rad, min(parts,3)), inches = FALSE,
-                add=TRUE, ...)
+                add=TRUE, bg = bg, ...)
     else {
         ## Draw ellipses with veganCovEllipse. Supply 2x2
         ## matrix(c(d,a,a,d), 2, 2) which defines an ellipse of
@@ -39,7 +45,7 @@ function(parts = 2, labels, ...)
         cnt <- sqrt(W/2)
         e1 <- veganCovEllipse(matrix(c(d,-a,-a,d), 2, 2), c(-cnt, -cnt))
         e4 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2), c( cnt, -cnt))
-        polygon(rbind(e1,NA,e2,NA,e3,NA,e4), ...)
+        polygon(rbind(e1,NA,e2,NA,e3,NA,e4), col = bg, ...)
     }
     nlabs <- switch(parts, 2, 4, 8, 16)
     if (missing(labels))

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,6 +1,17 @@
-`showvarparts` <-
-    function(parts = 2, labels, bg = NULL, alpha=63, ...)
+showvarpartsX <-
+    function(parts = 2, labels, bg = NULL, alpha=63, Xnames=c("X1","X2","X3","X4"), cex.main=1.2, ...)
 {
+### Internal function
+veganCovEllipse <-    
+function (cov, center = c(0, 0), scale = 1, npoints = 100) 
+# Call this function as    vegan:::veganCovEllipse
+{
+    theta <- (0:npoints) * 2 * pi/npoints
+    Circle <- cbind(cos(theta), sin(theta))
+    t(center + scale * t(Circle %*% chol(cov)))
+}
+### End internal function
+
     rad <- 0.725
     ## transparent fill colours
     if (!is.null(bg)) {
@@ -11,15 +22,15 @@
     ## centroids of circles (parts < 4) or individual fractions (parts
     ## == 4)
     cp <- switch(parts,
-                 matrix(c(0,0), ncol=2, byrow=TRUE),
-                 matrix(c(0,0, 1,0), ncol=2, byrow=TRUE),
-                 matrix(c(0,0, 1,0, 0.5, -sqrt(3/4)), ncol=2, byrow=TRUE),
-                 structure(
-                     c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0, 0.7, 0.7,
-                       0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7, 0, 0.3, 0.4,
-                       -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0, -0.7, -0.4),
-                     .Dim = c(15L, 2L))
-                 )
+        matrix(c(0,0), ncol=2, byrow=TRUE),
+        matrix(c(0,0, 1,0), ncol=2, byrow=TRUE),
+        matrix(c(0,0, 1,0, 0.5, -sqrt(3/4)), ncol=2, byrow=TRUE),
+        structure(
+            c(-1.2, -0.6, 0.6, 1.2, -0.7, 0, -0.7, 0, 0.7, 0.7,
+            0.3, -0.4, 0.4, -0.3, 0, 0, 0.7, 0.7, 0, 0.3, 0.4,
+            -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0, -0.7, -0.4),
+            .Dim = c(15L, 2L))
+        )
     ## plot limits
     if (parts < 4) {
         xlim <- range(cp[,1]) + c(-rad, rad)
@@ -32,19 +43,17 @@
     plot(cp, axes=FALSE, xlab="", ylab="", asp=1, type="n", 
          xlim = xlim, ylim = ylim)
     box()
-    if (parts < 4) 
+    if (parts < 4) {
         symbols(cp, circles = rep(rad, min(parts,3)), inches = FALSE,
                 add=TRUE, bg = bg, ...)
         # Explanatory data set names added by PL
         if(parts==2) {
-            text(-0.65,0.65,labels="X1", cex=1.2)
-            text( 1.65,0.65,labels="X2", cex=1.2)
-        } else if(parts==3) {
-            text(-0.65,0.65,labels="X1", cex=1.2)
-            text( 1.65,0.65,labels="X2", cex=1.2)
-            text(-0.16,-1.5,labels="X3", cex=1.2)
-        }
-    else {
+        	pos.names = matrix(c(-0.65,1.65,0.65,0.65),2,2)
+        	} else if(parts==3) {
+        	pos.names = matrix(c(-0.65,1.65,-0.16,0.65,0.65,-1.5),3,2)
+        	}
+        text(pos.names,labels=Xnames[1:parts], cex=cex.main)
+    } else {
         ## Draw ellipses with veganCovEllipse. Supply 2x2
         ## matrix(c(d,a,a,d), 2, 2) which defines an ellipse of
         ## semi-major axis length sqrt(d+a) semi-minor axis sqrt(d-a).
@@ -63,11 +72,10 @@
         e4 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2), c( cnt, -cnt))
         polygon(rbind(e1,NA,e2,NA,e3,NA,e4), col = bg, ...)
         # Explanatory data set names added by PL
-        text(-1.62,0.54,labels="X1", cex=1.2)
-        text(-1.10,1.00,labels="X2", cex=1.2)
-        text( 1.10,1.00,labels="X3", cex=1.2)
-        text( 1.62,0.54,labels="X4", cex=1.2)
+        pos.names = matrix(c(-1.62,-1.10,1.10,1.62,0.54,1.00,1.00,0.54),4,2)
+        text(pos.names,labels=Xnames[1:4], cex=cex.main)
     }
+    
     ## label fractions
     nlabs <- switch(parts, 2, 4, 8, 16)
     if (missing(labels))

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -8,6 +8,8 @@
         if (length(bg) < parts)
             bg <- rep(bg, length.out = parts)
     }
+    ## centroids of circles (parts < 4) or individual fractions (parts
+    ## == 4)
     cp <- switch(parts,
                  matrix(c(0,0), ncol=2, byrow=TRUE),
                  matrix(c(0,0, 1,0), ncol=2, byrow=TRUE),
@@ -18,6 +20,7 @@
                        -0.6,-1.2, -0.6, 0.3, -0.7, 0, 0, -0.7, -0.4),
                      .Dim = c(15L, 2L))
                  )
+    ## plot limits
     if (parts < 4) {
         xlim <- range(cp[,1]) + c(-rad, rad)
         ylim <- range(cp[,2]) + c(-rad, rad)
@@ -25,6 +28,7 @@
         xlim <- c(-1.7, 1.7)
         ylim <- c(-1.7, 1.1)
     }
+    ## plot
     plot(cp, axes=FALSE, xlab="", ylab="", asp=1, type="n", 
          xlim = xlim, ylim = ylim)
     box()
@@ -50,6 +54,7 @@
         e4 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2), c( cnt, -cnt))
         polygon(rbind(e1,NA,e2,NA,e3,NA,e4), col = bg, ...)
     }
+    ## label fractions
     nlabs <- switch(parts, 2, 4, 8, 16)
     if (missing(labels))
         labels <- paste("[", letters[1:nlabs], "]", sep="")

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,6 +1,17 @@
-`showvarparts` <-
+showvarpartsX <-
     function(parts = 2, labels, bg = NULL, alpha=63, ...)
 {
+### Internal function
+veganCovEllipse <-    
+function (cov, center = c(0, 0), scale = 1, npoints = 100) 
+# Call this function as    vegan:::veganCovEllipse
+{
+    theta <- (0:npoints) * 2 * pi/npoints
+    Circle <- cbind(cos(theta), sin(theta))
+    t(center + scale * t(Circle %*% chol(cov)))
+}
+### End internal function
+
     rad <- 0.725
     ## transparent fill colours
     if (!is.null(bg)) {
@@ -35,6 +46,15 @@
     if (parts < 4) 
         symbols(cp, circles = rep(rad, min(parts,3)), inches = FALSE,
                 add=TRUE, bg = bg, ...)
+        # Explanatory data set names added by PL
+        if(parts==2) {
+            text(-0.65,0.65,labels="X1", cex=1.2)
+            text( 1.65,0.65,labels="X2", cex=1.2)
+        } else if(parts==3) {
+            text(-0.65,0.65,labels="X1", cex=1.2)
+            text( 1.65,0.65,labels="X2", cex=1.2)
+            text(-0.16,-1.5,labels="X3", cex=1.2)
+        }
     else {
         ## Draw ellipses with veganCovEllipse. Supply 2x2
         ## matrix(c(d,a,a,d), 2, 2) which defines an ellipse of
@@ -53,6 +73,11 @@
         e1 <- veganCovEllipse(matrix(c(d,-a,-a,d), 2, 2), c(-cnt, -cnt))
         e4 <- veganCovEllipse(matrix(c(d, a, a,d), 2, 2), c( cnt, -cnt))
         polygon(rbind(e1,NA,e2,NA,e3,NA,e4), col = bg, ...)
+        # Explanatory data set names added by PL
+        text(-1.62,0.54,labels="X1", cex=1.2)
+        text(-1.10,1.00,labels="X2", cex=1.2)
+        text( 1.10,1.00,labels="X3", cex=1.2)
+        text( 1.62,0.54,labels="X4", cex=1.2)
     }
     ## label fractions
     nlabs <- switch(parts, 2, 4, 8, 16)
@@ -72,4 +97,3 @@
          paste("Residuals =", labels[nlabs]), pos = 2, ...)
     invisible()
 }
-

--- a/R/showvarparts.R
+++ b/R/showvarparts.R
@@ -1,5 +1,5 @@
 `showvarparts` <-
-    function(parts, labels, bg = NULL, alpha=63, Xnames, cex.main=1.2, ...)
+    function(parts, labels, bg = NULL, alpha=63, Xnames, id.size=1.2, ...)
 {
     rad <- 0.725
     ## Default names
@@ -44,7 +44,7 @@
         } else if(parts==3) {
             pos.names = matrix(c(-0.65,1.65,-0.16,0.65,0.65,-1.5),3,2)
         }
-        text(pos.names,labels=Xnames[1:parts], cex=cex.main)
+        text(pos.names,labels=Xnames[1:parts], cex=id.size)
     } else {
         ## Draw ellipses with veganCovEllipse. Supply 2x2
         ## matrix(c(d,a,a,d), 2, 2) which defines an ellipse of
@@ -65,7 +65,7 @@
         polygon(rbind(e1,NA,e2,NA,e3,NA,e4), col = bg, ...)
         ## Explanatory data set names added by PL
         pos.names = matrix(c(-1.62,-1.10,1.10,1.62,0.54,1.00,1.00,0.54),4,2)
-        text(pos.names,labels=Xnames[1:4], cex=cex.main)
+        text(pos.names,labels=Xnames[1:4], cex=id.size)
     }
     
     ## label fractions

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -21,7 +21,7 @@
 
 \usage{
 varpart(Y, X, ..., data, transfo, scale = FALSE)
-showvarparts(parts, labels, ...)
+showvarparts(parts, labels, bg = NULL, alpha = 63, ...)
 \method{plot}{varpart234}(x, cutoff = 0, digits = 1, ...)
 }
 
@@ -53,6 +53,12 @@ table. }
 \item{parts}{Number of explanatory tables (circles) displayed.}
 \item{labels}{Labels used for displayed fractions. Default is to use
   the same letters as in the printed output.}
+\item{bg}{Fill colours of circles or ellipses.}
+\item{alpha}{Transparency of the fill colour.  The argument takes
+    precedence over possible transparency definitions of the
+    colour. The value must be in range \eqn{0...255}, and low values
+    are more transparent.  Transparency is not available in all
+    graphics devices or file formats.}
 \item{x}{The \code{varpart} result.}
 \item{cutoff}{The values below \code{cutoff} will not be displayed.}
 \item{digits}{The number of significant digits; the number of decimal
@@ -239,11 +245,9 @@ vegandocs("partition")
 mod <- varpart(mite, ~ ., mite.pcnm, data=mite.env, transfo="hel")
 mod
 
-## argument 'bg' is passed to circle drawing, and the following
-## defines semitransparent colours
-col2 <- rgb(c(1,1),c(1,0), c(0,1), 0.3)
-showvarparts(2, bg = col2)
-plot(mod, bg = col2)
+## Use fill colours
+showvarparts(2, bg = c("hotpink","skyblue")
+plot(mod, bg = c("hotpink","skyblue")
 # Alternative way of to conduct this partitioning
 # Change the data frame with factors into numeric model matrix
 mm <- model.matrix(~ SubsDens + WatrCont + Substrate + Shrub + Topo, mite.env)[,-1]
@@ -258,8 +262,8 @@ RsquareAdj(aFrac)
 mod <- varpart(mite, ~ SubsDens + WatrCont, ~ Substrate + Shrub + Topo,
    mite.pcnm, data=mite.env, transfo="hel")
 mod
-showvarparts(3)
-plot(mod)
+showvarparts(3, bg=2:4)
+plot(mod, bg=2:4)
 # An alternative formulation of the previous model using
 # matrices mm1 amd mm2 and Hellinger transformed species data
 mm1 <- model.matrix(~ SubsDens + WatrCont, mite.env)[,-1]
@@ -276,9 +280,9 @@ anova(rda.result, step=200, perm.max=200)
 mod <- varpart(mite, ~ SubsDens + WatrCont, ~Substrate + Shrub + Topo,
   mite.pcnm[,1:11], mite.pcnm[,12:22], data=mite.env, transfo="hel")
 mod
-plot(mod)
+plot(mod, bg=2:5)
 # Show values for all partitions by putting 'cutoff' low enough:
-plot(mod, cutoff = -Inf, cex = 0.7)
+plot(mod, cutoff = -Inf, cex = 0.7, bg=2:5)
 }
 
 \keyword{ multivariate }

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -22,7 +22,7 @@
 \usage{
 varpart(Y, X, ..., data, transfo, scale = FALSE)
 showvarparts(parts, labels, bg = NULL, alpha = 63, Xnames,
-    cex.main = 1.2,  ...)
+    id.size = 1.2,  ...)
 \method{plot}{varpart234}(x, cutoff = 0, digits = 1, ...)
 }
 
@@ -61,13 +61,13 @@ table. }
     are more transparent.  Transparency is not available in all
     graphics devices or file formats.}
   
-\item{Xnames}{Explanatory file names. Default names are \code{X1},
+\item{Xnames}{Names for sources of variation. Default names are \code{X1},
   \code{X2}, \code{X3} and \code{X4}. \code{Xnames=NA},
   \code{Xnames=NULL} and \code{Xnames=""} produce no names. The names
   can be changed to other names. Use short names. }
 
-\item{cex.main}{A numerical value giving the amount by which characters
-  in the explanatory file names should be scaled }
+\item{id.size}{A numerical value giving the character expansion factor
+  for the names of circles or ellipses. }
 
 \item{x}{The \code{varpart} result.}
 \item{cutoff}{The values below \code{cutoff} will not be displayed.}

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -21,7 +21,8 @@
 
 \usage{
 varpart(Y, X, ..., data, transfo, scale = FALSE)
-showvarparts(parts, labels, bg = NULL, alpha = 63, ...)
+showvarparts(parts, labels, bg = NULL, alpha = 63, Xnames,
+    cex.main = 1.2,  ...)
 \method{plot}{varpart234}(x, cutoff = 0, digits = 1, ...)
 }
 
@@ -59,6 +60,15 @@ table. }
     colour. The value must be in range \eqn{0...255}, and low values
     are more transparent.  Transparency is not available in all
     graphics devices or file formats.}
+  
+\item{Xnames}{Explanatory file names. Default names are \code{X1},
+  \code{X2}, \code{X3} and \code{X4}. \code{Xnames=NA},
+  \code{Xnames=NULL} and \code{Xnames=""} produce no names. The names
+  can be changed to other names. Use short names. }
+
+\item{cex.main}{A numerical value giving the amount by which characters
+  in the explanatory file names should be scaled }
+
 \item{x}{The \code{varpart} result.}
 \item{cutoff}{The values below \code{cutoff} will not be displayed.}
 \item{digits}{The number of significant digits; the number of decimal
@@ -119,10 +129,17 @@ table. }
   \code{[n]}, and the joint fraction between all four tables is
   \code{[o]}.
 
-  There is a \code{plot} function that displays the Venn
-  diagram and labels each intersection (individual fraction) with the
-  adjusted R squared if this is higher than \code{cutoff}.  A helper
-  function \code{showvarpart} displays the fraction labels.
+  There is a \code{plot} function that displays the Venn diagram and
+  labels each intersection (individual fraction) with the adjusted R
+  squared if this is higher than \code{cutoff}.  A helper function
+  \code{showvarpart} displays the fraction labels. The circles and
+  ellipses are labelled by short default names or by names defined by
+  the user in argument \code{Xnames}. Longer explanatory file names can
+  be written on the varpart output plot as follows: use option
+  \code{Xnames=NA}, then add new names using the \code{text} function. A
+  bit of fiddling with coordinates (see \code{\link{locator}}) and
+  character size should allow users to place names of reasonably short
+  lengths on the \code{varpart} plot.
   
 }
 


### PR DESCRIPTION
This PR re-designs 4-part plots of `varpart` as four ellipses instead of three circles and two rectangles. The new design is picked up from Legendre, Borcard & Roberts, *Ecology* **93**,1234-1240 (2012), and looks like this in `example(varpart)`:
![varpart4](https://cloud.githubusercontent.com/assets/1432933/5792913/84f20e9a-9f37-11e4-9922-a327f33959e6.png)

The PR also adds arguments for background colour and its transparency.

I also considered adding an option of labelling the component circels/ellipses, but my attempts had too many lines of code and too many conditions (`if`)  to make a neat function, and therefore this was skipped.