### PR TITLE
circumvent getSaveFile file extension bug in Tcl/Tk in Windows

### DIFF
--- a/R/orditkplot.R
+++ b/R/orditkplot.R
@@ -164,7 +164,8 @@
                        command=function() tcltk::tkpostscript(can, x=0, y=0,
                        height=height, width=width,
                        file=tcltk::tkgetSaveFile(
-                         filetypes="{{EPS file} {.eps}}")))
+                         filetypes="{{EPS file} {.eps}}",
+                         defaultextension=".eps")))
     dismiss <- tcltk::tkbutton(buts, text="Dismiss",
                                command=function() tcltk::tkdestroy(w))
     ## Dump current plot to an "orditkplot" object (internally)
@@ -244,7 +245,18 @@
         if (!isTRUE(unname(capabilities("tiff"))))
             falt["tiff"] <- FALSE
         ftypes <- ftypes[falt]
-        fname <- tcltk::tkgetSaveFile(filetypes=ftypes)
+        ## External Tcl/Tk in Windows seems to buggy with type
+        ## extensions of the file name: the extension is not
+        ## automatically appended, but defaultextension is interpreted
+        ## wrongly so that its value is not used as extension but
+        ## correct appending is done if defaultextension has any
+        ## value. The following kluge is against Tcl/Tk documentation,
+        ## and should be corrected if Tcl/Tk is fixed.
+        if (.Platform$OS.type == "windows")
+            fname <- tcltk::tkgetSaveFile(filetypes=ftypes,
+                                          defaultextension = TRUE)
+        else
+            fname <- tcltk::tkgetSaveFile(filetypes=ftypes)
         if(tcltk::tclvalue(fname) == "")
             return(NULL)
         fname <- tcltk::tclvalue(fname)


### PR DESCRIPTION
**Tcl/Tk** documentation says that `tk_getSaveFile` should automatically
append an appropriate file extension if none is given, but that
can be overridden with `defaultextension`. This happens in Linux
and Mac, but in Windows no extension is added to the plain name.
However, if `defaultextension` has any value in Windows, the correct
extension is added to the plain name instead of using the value
of `defaultextension`.

This is clearly a **Tcl/Tk** bug, and has been reported several times
on the Web. If **Tcl/Tk** in Windows is fixed, this kluge should be
removed.

The fix should be  tested in Windows.