### PR TITLE
Fix goodness functions for partial constrained ordination 

### DIFF
--- a/R/goodness.cca.R
+++ b/R/goodness.cca.R
@@ -39,7 +39,8 @@
                 Xbar <- t(Xbar)
             ptot <- diag(crossprod(Xbar))
             tot <- tot + ptot
-            vexp <- sweep(vexp, 1, ptot, "+")
+            if (model == "CCA")
+                vexp <- sweep(vexp, 1, ptot, "+")
         }
         vexp <- sweep(vexp, 1, tot, "/")
     }

--- a/R/goodness.cca.R
+++ b/R/goodness.cca.R
@@ -28,9 +28,12 @@
         }
         v <- sweep(object[[model]]$u, 2, lambda2, "*")
     }
+    if (ncol(v) > 1)
+        vexp <- t(apply(v^2, 1, cumsum))
+    else
+        vexp <- v^2
     if (!missing(choices)) 
-        v <- v[, choices, drop = FALSE]
-    vexp <- t(apply(v^2, 1, cumsum))
+        vexp <- vexp[, choices, drop = FALSE]
     if (statistic == "explained") {
         vexp <- sweep(vexp, 1, cs, "*")
         if (!is.null(object$pCCA)) {

--- a/R/goodness.rda.R
+++ b/R/goodness.rda.R
@@ -15,7 +15,7 @@
     cs <- weights(object, display = display)
     lambda2 <- sqrt(object[[model]]$eig)
     if (display == "species") {
-        if (is.null(object$CCA)) 
+        if (is.null(object$CCA))
             Xbar <- object$CA$Xbar
         else Xbar <- object$CCA$Xbar
         v <- sweep(object[[model]]$v, 2, lambda2, "*")
@@ -43,7 +43,7 @@
             Xbar <- object$pCCA$Fit
             if (display == "sites") 
                 Xbar <- t(Xbar)
-            ptot <- diag(crossprod(Xbar))
+            ptot <- diag(crossprod(Xbar))/(nrow(Xbar)-1)
             tot <- tot + ptot
             vexp <- sweep(vexp, 1, ptot, "+")
         }

--- a/R/goodness.rda.R
+++ b/R/goodness.rda.R
@@ -45,7 +45,8 @@
                 Xbar <- t(Xbar)
             ptot <- diag(crossprod(Xbar))/(nrow(Xbar)-1)
             tot <- tot + ptot
-            vexp <- sweep(vexp, 1, ptot, "+")
+            if (model == "CCA")
+                vexp <- sweep(vexp, 1, ptot, "+")
         }
         vexp <- sweep(vexp, 1, tot, "/")
     }

--- a/R/goodness.rda.R
+++ b/R/goodness.rda.R
@@ -34,10 +34,13 @@
         }
         v <- sweep(object[[model]]$u, 2, lambda2, "*")
     }
-    if (!missing(choices)) 
-        v <- v[, choices, drop = FALSE]
-    vexp <- t(apply(v^2, 1, cumsum))
+    if (ncol(v) > 1)
+        vexp <- t(apply(v^2, 1, cumsum))
+    else
+        vexp <- v^2
     vexp <- sweep(vexp, 1, cs, "*")
+    if (!missing(choices)) 
+        vexp <- vexp[, choices, drop = FALSE]
     if (statistic == "explained") {
         if (!is.null(object$pCCA)) {
             Xbar <- object$pCCA$Fit

--- a/man/goodness.cca.Rd
+++ b/man/goodness.cca.Rd
@@ -52,8 +52,10 @@ vif.cca(object)
   Function \code{goodness} gives the diagnostic statistics for species
   or sites. The alternative statistics are the cumulative proportion of
   inertia accounted for by the axes, and the residual distance left
-  unaccounted for.  The conditional (\dQuote{partialled out}) constraints are
-  always regarded as explained and included in the statistics.
+  unaccounted for.  The conditional (\dQuote{partialled out})
+  constraints are always regarded as explained and included in the
+  statistics of the constrained component with\code{model = "CCA"}
+  (but not in the residual component with \code{model = "CA"}).
 
   Function \code{inertcomp} decomposes the inertia into partial,
   constrained and unconstrained components for each site or

--- a/man/goodness.cca.Rd
+++ b/man/goodness.cca.Rd
@@ -51,7 +51,7 @@ vif.cca(object)
 \details{
   Function \code{goodness} gives the diagnostic statistics for species
   or sites. The alternative statistics are the cumulative proportion of
-  inertia accounted for by the axes, and the residual distance left
+  inertia accounted for up to the axes, and the residual distance left
   unaccounted for.  The conditional (\dQuote{partialled out})
   constraints are always regarded as explained and included in the
   statistics of the constrained component with\code{model = "CCA"}


### PR DESCRIPTION
This PR fixes problems emerging when inspecting an [R-sig-ecology message](https://stat.ethz.ch/pipermail/r-sig-ecology/2015-March/004936.html) by Christoph Eberhard:

1. The variance of partial component was overestimated by a factor of *N-1* in `goodness.rda`. 
2. `goodness.rda`  and `goodness.cca`  added the partial component of the variation both to the constrained (`model = "CCA"`) and residual (`model = "CA"`) component so that it was added twice. For any constrained ordination model `m`, the following should give a vector of ones: `goodness(m, model = "CCA", sum=TRUE) + goodness(m, mod = "CA", sum=TRUE)`, but that failed in partial models.
3. If only one axis was chosen, the result dropped to a vector and `goodness.cca`  and `goodness.rda` gave warnings.
4. The results were inconsistent when only some axes were chosen. Now cumulative sums are evaluated prior to choosing axes so that the proportion explained by axis 'k' no longer depends on the axes selected before 'k'.

It seems that all these problems were present when these functions were released in **vegan** 1.6-7 on Jan 24, 2005 so that they have persisted longer than a decade.