### PR TITLE
Fail earlier if 'dis' is not class 'dist' or a square matrix-like object

### DIFF
--- a/R/pcnm.R
+++ b/R/pcnm.R
@@ -1,6 +1,11 @@
-`pcnm` <-
-    function(dis, threshold, w, dist.ret = FALSE)
-{
+`pcnm` <- function(dis, threshold, w, dist.ret = FALSE) {
+    if (!inherits(dis, "dist")) {
+        dims <- dim(dis)
+        if (length(unique(dims)) >1) {
+            stop("'dis' does not appear to be a square distance matrix.")
+        }
+        dis <- as.dist(dis)
+    }
     EPS <- sqrt(.Machine$double.eps)
     wa.old <- options(warn = -1)
     on.exit(options(wa.old))
@@ -16,7 +21,7 @@
     res <- list(vectors = mypcnm$points, values = mypcnm$eig,
                 weights = mypcnm$weig)
     k <- ncol(mypcnm$points)
-    res$vectors <- sweep(res$vectors, 2, sqrt(res$values[1:k]), "/")
+    res$vectors <- sweep(res$vectors, 2, sqrt(res$values[seq_len(k)]), "/")
     colnames(res$vectors) <- paste("PCNM", 1:k, sep="")
     res$threshold <- threshold
     if (dist.ret) {


### PR DESCRIPTION
This addresses the issue raised in #110 and implements a check for a square matrix if `dis` does not inherit from class `"dist"`. The check now throws an error indicating a non-square matrix if this check fails.

This avoids the rather cryptic error message that is thrown much later in the current code after the `wcdmscale()` call.  