### PR TITLE
One point hulls and ellipses

### DIFF
--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -37,8 +37,15 @@
     kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
         gr <- out[groups == is & kk]
-        if (length(gr) > 1) {
-            X <- pts[gr, ]
+        if (length(gr)) {
+            X <- pts[gr, , drop = FALSE]
+            ## one-point ellipses are labelled but not returned in the
+            ## result object (nor calculated)
+            if (length(gr) == 1) {
+                cntrs <- rbind(cntrs, X)
+                names <- c(names, is)
+                next
+            }
             W <- w[gr]
             mat <- cov.wt(X, W)
             if (kind == "se")

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -39,21 +39,19 @@
         gr <- out[groups == is & kk]
         if (length(gr)) {
             X <- pts[gr, , drop = FALSE]
-            ## one-point ellipses are labelled but not returned in the
-            ## result object (nor calculated)
-            if (length(gr) == 1) {
-                cntrs <- rbind(cntrs, X)
-                names <- c(names, is)
-                next
-            }
             W <- w[gr]
             mat <- cov.wt(X, W)
+            if (mat$n.obs == 1)
+                mat$cov[] <- 0
             if (kind == "se")
                 mat$cov <- mat$cov/mat$n.obs
             if (missing(conf))
                 t <- 1
             else t <- sqrt(qchisq(conf, 2))
-            xy <- veganCovEllipse(mat$cov, mat$center, t)
+            if (mat$n.obs > 1)
+                xy <- veganCovEllipse(mat$cov, mat$center, t)
+            else
+                xy <- X
             if (draw == "lines")
                 ordiArgAbsorber(xy, FUN = lines,
                                 col = if(is.null(col)) par("fg") else col,

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -33,8 +33,13 @@
     kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
         gr <- out[groups == is & kk]
-        if (length(gr) > 1) {
-            X <- pts[gr, ]
+        if (length(gr)) {
+            X <- pts[gr,, drop = FALSE]
+            if (length(gr) == 1) {
+                cntrs <- rbind(cntrs, X)
+                names <- c(names, is)
+                next
+            }
             hpts <- chull(X)
             hpts <- c(hpts, hpts[1])
             if (draw == "lines")

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -8,7 +8,7 @@
     polycentre <- function(x) {
         n <- nrow(x)
         if (n < 4) 
-            return(colMeans(x[-n, ]))
+            return(colMeans(x[-n, , drop = FALSE]))
         xy <- x[-n, 1] * x[-1, 2] - x[-1, 1] * x[-n, 2]
         A <- sum(xy)/2
         xc <- sum((x[-n, 1] + x[-1, 1]) * xy)/A/6
@@ -35,11 +35,6 @@
         gr <- out[groups == is & kk]
         if (length(gr)) {
             X <- pts[gr,, drop = FALSE]
-            if (length(gr) == 1) {
-                cntrs <- rbind(cntrs, X)
-                names <- c(names, is)
-                next
-            }
             hpts <- chull(X)
             hpts <- c(hpts, hpts[1])
             if (draw == "lines")

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -27,8 +27,10 @@
     out <- seq(along = groups)
     inds <- names(table(groups))
     res <- list()
-    if (label)
-        cntrs <- names <- NULL
+    if (label) {
+        cntrs <- matrix(NA, nrow=length(inds), ncol=2)
+        rownames(cntrs) <- inds
+    }
     ## Remove NA scores
     kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
@@ -43,18 +45,17 @@
             else if (draw == "polygon")
                 ordiArgAbsorber(X[hpts,], FUN = polygon, col = col, ...)
             if (label && draw != "none") {
-                cntrs <- rbind(cntrs, polycentre(X[hpts,]))
-                names <- c(names, is)
+                cntrs[is,] <- polycentre(X[hpts,])
             }
             res[[is]] <- X[hpts,]
         }
     }
     if (label && draw != "none") {
         if (draw == "lines")
-            ordiArgAbsorber(cntrs[,1], cntrs[,2], labels = names,
+            ordiArgAbsorber(cntrs[,1], cntrs[,2], 
                             col = col, FUN = text, ...)
         else
-            ordiArgAbsorber(cntrs, labels = names, col = NULL,
+            ordiArgAbsorber(cntrs, col = NULL,
                             FUN = ordilabel, ...)
     }
     class(res) <- "ordihull"

--- a/R/summary.ordiellipse.R
+++ b/R/summary.ordiellipse.R
@@ -5,9 +5,11 @@
     function(object, ...)
 {
     cnts <- sapply(object, function(x) x$center)
-    ## two points are exactly on line and have zero area ellipses
+    ## 2nd eigenvalue should be zero if points are on line (like two
+    ## points), but sometimes it comes out negative, and area is NaN
     areas <- sapply(object,
-                    function(x) if (x$n.obs <= 2) 0 else
-                    prod(sqrt(eigen(x$cov)$values)) * pi * x$scale^2)
+                    function(x)
+                        prod(sqrt(pmax(0, eigen(x$cov)$values))) *
+                            pi * x$scale^2)
     rbind(cnts, `Area` = areas)
 }

--- a/R/summary.ordiellipse.R
+++ b/R/summary.ordiellipse.R
@@ -5,8 +5,9 @@
     function(object, ...)
 {
     cnts <- sapply(object, function(x) x$center)
+    ## two points are exactly on line and have zero area ellipses
     areas <- sapply(object,
-                    function(x)
+                    function(x) if (x$n.obs <= 2) 0 else
                     prod(sqrt(eigen(x$cov)$values)) * pi * x$scale^2)
     rbind(cnts, `Area` = areas)
 }

--- a/R/summary.ordihull.R
+++ b/R/summary.ordihull.R
@@ -12,7 +12,7 @@
     polycentre <- function(x) {
         n <- nrow(x)
         if (n < 4)
-            return(colMeans(x[-n,]))
+            return(colMeans(x[-n,, drop = FALSE]))
         xy <- x[-n,1]*x[-1,2] - x[-1,1]*x[-n,2]
         A <- sum(xy)/2
         xc <- sum((x[-n,1] + x[-1,1]) * xy)/A/6


### PR DESCRIPTION
This PR gives a simple solution to a problem raised in StackOverflow http://stackoverflow.com/questions/30487677/ordihull-label-with-single-occurance about labelling one-point convex-hulls in `ordihull`. With this PR the hulls are labelled but nor drawn nor returned. The same enhancement was also made to `ordiellipse`: one-point ellipses are labelled, but not drawn nor returned. It could be argued that the (invisible) return object has information on these one-point cases as well, but that requires a bit more work, because `summary` and `ordiareatest` should work for these one-point cases, too. 

Function `ordispider` already works ideally: it labels one-point spiders but does not draw them. However, it also returns the "centroid" of one point (or the coordinates of that one point). 