### PR TITLE
Handle imaginary axes in capscale

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -36,6 +36,8 @@ export(pasteCall)
 export(anova.cca)
 ## Export as.mcmc for coda
 export(as.mcmc.oecosimu, as.mcmc.permat)
+## export oldCapscale for compatibility after new capscale design
+export(oldCapscale)
 
 ## export regular functions with dot names
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -95,7 +95,6 @@ S3method(RsquareAdj, default)
 S3method(RsquareAdj, glm)
 S3method(RsquareAdj, lm)
 S3method(RsquareAdj, rda)
-S3method(RsquareAdj, capscale)
 # TukeyHSD: stats
 S3method(TukeyHSD, betadisper)
 # add1: stats

--- a/R/RsquareAdj.R
+++ b/R/RsquareAdj.R
@@ -33,19 +33,6 @@
     list(r.squared = R2, adj.r.squared = radj)
 }
 
-## dbRDA: Euclidean style distances with no imaginary component can be
-## handled as rda, but I have no idea how to handle objects with
-## imaginary inertia.
-
-`RsquareAdj.capscale` <-
-    function(x, ...)
-{
-    if (!is.null(x$CA$imaginary.chi))
-        list(r.squared = NA, adj.r.squared = NA)
-    else
-        NextMethod("RsquareAdj", x, ...)
-}
-
 ## cca result: no RsquareAdj
 RsquareAdj.cca <-
     function(x, ...)

--- a/R/anova.ccabyterm.R
+++ b/R/anova.ccabyterm.R
@@ -17,20 +17,23 @@
     trmlab <- trmlab[trmlab %in% attr(terms(object$terminfo),
                                       "term.labels")]
     ntrm <- length(trmlab)
-    m0 <- update(object, paste(".~.-", paste(trmlab, collapse="-")))
+    m0 <- update(object, paste(".~.-", paste(trmlab, collapse = "-")))
     mods <- list(m0)
-    for(i in seq_along(trmlab)) {
+    for (i in seq_along(trmlab)) {
         fla <- paste(". ~ . + ", trmlab[i])
         mods[[i+1]] <- update(mods[[i]], fla)
     }
+    ## for compatibility with the old capscale design we need the following
+    if (inherits(object, "oldcapscale")) # uh -- get rid of this later
+        mods <- suppressMessages(lapply(mods, oldCapscale))
     ## The result
     sol <- anova.ccalist(mods, permutations = permutations,
                          model = model, parallel = parallel)
     ## Reformat
-    out <- data.frame(c(sol[-1,3], sol[ntrm+1,1]),
-                      c(sol[-1,4], sol[ntrm+1,2]),
-                      c(sol[-1,5], NA),
-                      c(sol[-1,6], NA))
+    out <- data.frame(c(sol[-1, 3], sol[ntrm+1, 1]),
+                      c(sol[-1, 4], sol[ntrm+1, 2]),
+                      c(sol[-1, 5], NA),
+                      c(sol[-1, 6], NA))
     isRDA <- inherits(object, "rda")
     colnames(out) <- c("Df", ifelse(isRDA, "Variance", "ChiSquare"),
                        "F", "Pr(>F)")
@@ -41,7 +44,8 @@
                    howHead(attr(permutations, "control")))
     mod <- paste("Model:", c(object$call))
     attr(out, "heading") <- c(head, mod)
-    class(out) <- c("anova","data.frame")
+    attr(out, "F.perm") <- attr(sol, "F.perm")
+    class(out) <- c("anova.cca", "anova","data.frame")
     out
 }
 
@@ -55,6 +59,9 @@
     ## Refuse to handle models with missing data
     if (!is.null(object$na.action))
         stop("by = 'margin' models cannot handle missing data")
+    ## Refuse to handle oldCapscale models
+    if (inherits(object, "oldcapscale"))
+        stop("by = 'margin' models cannot handle oldCapscale results")
     ## We need term labels but without Condition() terms
     if (!is.null(scope) && is.character(scope))
         trms <- scope
@@ -62,7 +69,7 @@
         trms <- drop.scope(object)
     trmlab <- trms[trms %in% attr(terms(object$terminfo),
                                       "term.labels")]
-    if(length(trmlab) == 0)
+    if (length(trmlab) == 0)
         stop("the scope was empty: no available marginal terms")
     ## baseline: all terms
     big <- permutest(object, permutations, ...)
@@ -85,7 +92,7 @@
     Fval <- sapply(mods, function(x) x$num)
     ## Had we an empty model we need to clone the denominator
     if (length(Fval) == 1)
-        Fval <- matrix(Fval, nrow=nperm)
+        Fval <- matrix(Fval, nrow = nperm)
     Fval <- sweep(-Fval, 1, big$num, "+")
     Fval <- sweep(Fval, 2, Df, "/")
     Fval <- sweep(Fval, 1, scale, "/")
@@ -104,7 +111,8 @@
                    howHead(attr(permutations, "control")))
     mod <- paste("Model:", c(object$call))
     attr(out, "heading") <- c(head, mod)
-    class(out) <- c("anova", "data.frame")
+    attr(out, "F.perm") <- Fval
+    class(out) <- c("anova.cca", "anova", "data.frame")
     out
 }
 
@@ -113,8 +121,11 @@
 `anova.ccabyaxis` <-
     function(object, permutations, model, parallel, cutoff = 1)
 {
+    ## capscale axes are still based only on real components and we
+    ## need to cast to old format to get the correct residual
+    ## variation. This should give a message().
     if (!is.null(object$CA$imaginary.chi))
-        stop("by = 'axis' cannot be used when there are negative eigenvalues")
+        object <- oldCapscale(object)
     nperm <- nrow(permutations)
     ## Observed F-values and Df
     eig <- object$CCA$eig
@@ -126,10 +137,10 @@
     ## missing values?
     if (!is.null(object$na.action))
         LC <- napredict(structure(object$na.action,
-                                  class="exclude"), LC)
+                                  class = "exclude"), LC)
     ## subset?
     if (!is.null(object$subset)) {
-        tmp <- matrix(NA, nrow=length(object$subset),
+        tmp <- matrix(NA, nrow = length(object$subset),
                       ncol = ncol(LC))
         tmp[object$subset,] <- LC
         LC <- tmp
@@ -138,6 +149,7 @@
     LC <- as.data.frame(LC)
     fla <- reformulate(names(LC))
     Pvals <- rep(NA, length(eig))
+    F.perm <- matrix(ncol = length(eig), nrow = nperm)
     environment(object$terms) <- environment()
     for (i in seq_along(eig)) {
         part <- paste("~ . +Condition(",
@@ -152,7 +164,8 @@
                 permutest(update(object, upfla, data = LC),
                           permutations, model = model,
                           parallel = parallel)
-        Pvals[i] <- (sum(mod$F.perm >= mod$F.0) + 1)/(nperm+1)
+        Pvals[i] <- (sum(mod$F.perm >= mod$F.0) + 1) / (nperm + 1)
+        F.perm[ , i] <- mod$F.perm
         if (Pvals[i] > cutoff)
             break
     }
@@ -168,6 +181,7 @@
                    howHead(attr(permutations, "control")))
     mod <- paste("Model:", c(object$call))
     attr(out, "heading") <- c(head, mod)
-    class(out) <- c("anova", "data.frame")
+    attr(out, "F.perm") <- F.perm
+    class(out) <- c("anova.cca", "anova", "data.frame")
     out
 }

--- a/R/anova.ccabyterm.R
+++ b/R/anova.ccabyterm.R
@@ -113,6 +113,8 @@
 `anova.ccabyaxis` <-
     function(object, permutations, model, parallel, cutoff = 1)
 {
+    if (!is.null(object$CA$imaginary.chi))
+        stop("by = 'axis' cannot be used when there are negative eigenvalues")
     nperm <- nrow(permutations)
     ## Observed F-values and Df
     eig <- object$CCA$eig

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -107,9 +107,14 @@
         sol$pCCA$tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))
         G <- qr.resid(sol$pCCA$QR, G)
     }
-    sol$CCA$G <- G
-    sol$CCA$tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
-    sol$CA$tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
+    if (!is.null(sol$CCA) && sol$CCA$rank > 0) {
+        sol$CCA$G <- G
+        sol$CCA$tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
+    }
+    if (!is.null(sol$CA) && !is.null(sol$CCA$QR))
+        sol$CA$tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
+    else
+        sol$CA$tot.chi <- sum(diag(G))
     if (!is.null(sol$CCA) && sol$CCA$rank > 0) {
         colnames(sol$CCA$u) <- colnames(sol$CCA$biplot) <- names(sol$CCA$eig) <-
             colnames(sol$CCA$wa) <- colnames(sol$CCA$v) <-

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -98,23 +98,35 @@
     ## McArdle & Anderson (2001), section "Theory". G is their
     ## double-centred Gower matrix, but instead of hat matrix, we use
     ## use QR decomposition to get the components of inertia.
+    hasNegEig <- any(sol$eig < 0)
     G <- -X$x/2
     if (adjust == 1)
         G <- G/k
+    if (hasNegEig)
+        sol$real.tot.chi <- sol$tot.chi
     sol$tot.chi <- sum(diag(G))
     if (!is.null(sol$pCCA)) {
         sol$pCCA$G <- G
-        sol$pCCA$tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))
+        if (hasNegEig) {
+            sol$pCCA$real.tot.chi <- sol$pCCA$tot.chi
+            sol$pCCA$tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))
+        }
         G <- qr.resid(sol$pCCA$QR, G)
     }
     if (!is.null(sol$CCA) && sol$CCA$rank > 0) {
         sol$CCA$G <- G
-        sol$CCA$tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
+        if (hasNegEig) {
+            sol$CCA$real.tot.chi <- sol$CCA$tot.chi
+            sol$CCA$tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
+        }
     }
-    if (!is.null(sol$CA) && !is.null(sol$CCA$QR))
-        sol$CA$tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
-    else
-        sol$CA$tot.chi <- sum(diag(G))
+    if (hasNegEig) {
+        sol$CA$real.tot.chi <- sol$CA$tot.chi
+        if (!is.null(sol$CA) && !is.null(sol$CCA$QR))
+            sol$CA$tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
+        else
+            sol$CA$tot.chi <- sum(diag(G))
+    }
     if (!is.null(sol$CCA) && sol$CCA$rank > 0) {
         colnames(sol$CCA$u) <- colnames(sol$CCA$biplot) <- names(sol$CCA$eig) <-
             colnames(sol$CCA$wa) <- colnames(sol$CCA$v) <-

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -98,7 +98,7 @@
     ## McArdle & Anderson (2001), section "Theory". G is their
     ## double-centred Gower matrix, but instead of hat matrix, we use
     ## use QR decomposition to get the components of inertia.
-    hasNegEig <- any(sol$eig < 0)
+    hasNegEig <- any(X$eig < 0)
     G <- -X$x/2
     if (adjust == 1)
         G <- G/k

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -101,15 +101,13 @@
     G <- -X$x/2
     if (adjust == 1)
         G <- G/k
-    itot.chi <- sum(diag(G))
+    sol$tot.chi <- sum(diag(G))
     if (!is.null(sol$pCCA)) {
-        ipcca.tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))
+        sol$pCCA$tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))
         G <- qr.resid(sol$pCCA$QR, G)
-    } else {
-        ipcca.tot.chi <- NULL
     }
-    icca.tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
-    ica.tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
+    sol$CCA$tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
+    sol$CA$tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
     if (!is.null(sol$CCA) && sol$CCA$rank > 0) {
         colnames(sol$CCA$u) <- colnames(sol$CCA$biplot) <- names(sol$CCA$eig) <-
             colnames(sol$CCA$wa) <- colnames(sol$CCA$v) <-
@@ -124,7 +122,6 @@
     if (any(X$eig < 0)) {
         negax <- X$eig[X$eig < 0]
         sol$CA$imaginary.chi <- sum(negax)
-        sol$tot.chi <- sol$tot.chi + sol$CA$imaginary.chi
         sol$CA$imaginary.rank <- length(negax)
         sol$CA$imaginary.u.eig <- X$negaxes
     }
@@ -181,8 +178,6 @@
         sol$metaMDSdist <- commname
     sol$subset <- d$subset
     sol$na.action <- d$na.action
-    sol$varcomps <- c("Total" = itot.chi, "pCCA" = ipcca.tot.chi,
-                      "CCA" = icca.tot.chi, "CA" = ica.tot.chi) 
     class(sol) <- c("capscale", class(sol))
     if (!is.null(sol$na.action))
         sol <- ordiNAexclude(sol, d$excluded)

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -99,6 +99,8 @@
     ## double-centred Gower matrix, but instead of hat matrix, we use
     ## use QR decomposition to get the components of inertia.
     G <- -X$x/2
+    if (adjust == 1)
+        G <- G/k
     itot.chi <- sum(diag(G))
     if (!is.null(sol$pCCA)) {
         ipcca.tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -103,9 +103,11 @@
         G <- G/k
     sol$tot.chi <- sum(diag(G))
     if (!is.null(sol$pCCA)) {
+        sol$pCCA$G <- G
         sol$pCCA$tot.chi <- sum(diag(qr.fitted(sol$pCCA$QR, G)))
         G <- qr.resid(sol$pCCA$QR, G)
     }
+    sol$CCA$G <- G
     sol$CCA$tot.chi <- sum(diag(qr.fitted(sol$CCA$QR, G)))
     sol$CA$tot.chi <- sum(diag(qr.resid(sol$CCA$QR, G)))
     if (!is.null(sol$CCA) && sol$CCA$rank > 0) {

--- a/R/oldCapscale.R
+++ b/R/oldCapscale.R
@@ -10,7 +10,7 @@
     function(object)
 {
     ## no imaginary component: nothing need be done
-    if (!is.null(object$CCA$imaginary.rank))
+    if (is.null(object$CA$imaginary.rank))
         return(object)
     ## inertia components based only on real dimensions
     object$tot.chi <- object$real.tot.chi

--- a/R/oldCapscale.R
+++ b/R/oldCapscale.R
@@ -1,0 +1,30 @@
+### Internal function to remove changes in capscale in vegan
+### 2.4-0. From vegan 2.4-0 inertia components include negative
+### eigenvalues of PCoA whereas earlier ordination and the components
+### were only based on real components of PCoA. This function puts
+### back the inertia components that ignore imaginary
+### dimensions. F-statistics etc will change as a result.  The
+### function is provided to maintain compatibility with the old vegan,
+### and may be eliminated in the future.
+`oldCapscale` <-
+    function(object)
+{
+    ## no imaginary component: nothing need be done
+    if (!is.null(object$CCA$imaginary.rank))
+        return(object)
+    ## inertia components based only on real dimensions
+    object$tot.chi <- object$real.tot.chi
+    if (!is.null(object$pCCA)) {
+        object$pCCA$tot.chi <- object$pCCA$real.tot.chi
+    }
+    if (!is.null(object$CCA)) {
+        object$CCA$tot.chi <- object$CCA$real.tot.chi
+    }
+    if (!is.null(object$CA)) {
+        object$CA$tot.chi <- object$CA$real.tot.chi
+    }
+    ## tell what you did
+    message("imaginary variation was discarded")
+    class(object) <- c("oldcapscale", class(object))
+    object
+}

--- a/R/ordiR2step.R
+++ b/R/ordiR2step.R
@@ -13,9 +13,6 @@
     ## Works only for rda(): cca() does not have (yet) R2.adjusted
     if (!inherits(object, "rda"))
         stop("can be used only with rda() or capscale()")
-    ## No R2 for capscale with negative eigenvalues
-    if (inherits(object, "capscale") && !is.null(object$CA$imaginary.chi))
-        stop("cannot be used when capscale() has negative eigenvalues")
     ## Get R2 of the original object
     if (is.null(object$CCA))
         R2.0 <- 0

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -21,18 +21,30 @@ permutest.default <- function(x, ...)
         return(sol)
     }
     model <- match.arg(model)
-    isCCA <- !inherits(x, "rda")
-    isPartial <- !is.null(x$pCCA)
+    ## special cases
+    isCCA <- !inherits(x, "rda")    # weighting
+    isPartial <- !is.null(x$pCCA)   # handle conditions
+    isDB <- inherits(x, "capscale") # distance-based
     ## Function to get the F statistics in one loop
     getF <- function (indx, ...)
     {
+        getEV <- function(x, isDB=FALSE)
+        {
+            if (isDB)
+                sum(diag(x))
+            else
+                sum(x*x)
+        }
         if (!is.matrix(indx))
             dim(indx) <- c(1, length(indx))
         R <- nrow(indx)
         mat <- matrix(0, nrow = R, ncol = 3)
         for (i in seq_len(R)) {
             take <- indx[i,]
-            Y <- E[take, ]
+            if (isDB)
+                Y <- E[take, take]
+            else
+                Y <- E[take, ]
             if (isCCA)
                 wtake <- w[take]
             if (isPartial) {
@@ -54,11 +66,15 @@ permutest.default <- function(x, ...)
             }
             tmp <- qr.fitted(Q, Y)
             if (first)
-                cca.ev <- La.svd(tmp, nv = 0, nu = 0)$d[1]^2
-            else cca.ev <- sum(tmp * tmp)
+                if (isDB)
+                    cca.ev <- eigen(tmp)$values[1]
+                else
+                    cca.ev <- La.svd(tmp, nv = 0, nu = 0)$d[1]^2
+            else
+                cca.ev <- getEV(tmp, isDB)
             if (isPartial || first) {
                 tmp <- qr.resid(Q, Y)
-                ca.ev <- sum(tmp * tmp)
+                ca.ev <- getEV(tmp, isDB)
             }
             else ca.ev <- Chi.tot - cca.ev
             mat[i,] <- cbind(cca.ev, ca.ev, (cca.ev/q)/(ca.ev/r))
@@ -82,7 +98,7 @@ permutest.default <- function(x, ...)
     if (model == "full")
         Chi.tot <- Chi.xz
     else Chi.tot <- Chi.z + Chi.xz
-    if (!isCCA)
+    if (!isCCA && !isDB)
         Chi.tot <- Chi.tot * (nrow(x$CCA$Xbar) - 1)
     F.0 <- (Chi.z/q)/(Chi.xz/r)
     Q <- x$CCA$QR
@@ -100,10 +116,11 @@ permutest.default <- function(x, ...)
         }
     }
     if (model == "reduced" || model == "direct")
-        E <- x$CCA$Xbar
-    else E <- x$CA$Xbar
+        E <- if (isDB) x$CCA$G else x$CCA$Xbar
+    else E <- if (isDB) stop("capscale cannot be used with 'full' model")
+              else x$CA$Xbar
     if (isPartial && model == "direct")
-        E <- E + Y.Z
+        E <- if (isDB) x$pCCA$G else E + Y.Z
     ## Save dimensions
     N <- nrow(E)
     if (isCCA) {

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -24,7 +24,8 @@ permutest.default <- function(x, ...)
     ## special cases
     isCCA <- !inherits(x, "rda")    # weighting
     isPartial <- !is.null(x$pCCA)   # handle conditions
-    isDB <- inherits(x, "capscale") # distance-based
+    isDB <- inherits(x, "capscale") &&
+        !inherits(x, "oldcapscale") # distance-based & new design
     ## Function to get the F statistics in one loop
     getF <- function (indx, ...)
     {

--- a/R/print.cca.R
+++ b/R/print.cca.R
@@ -7,21 +7,18 @@
     }
     writeLines(strwrap(pasteCall(x$call)))
     cat("\n")
-    chi <- c(x$tot.chi, if (!is.null(x$CA$imaginary.chi)) x$tot.chi - x$CA$imaginary.chi,
-                            x$pCCA$tot.chi, x$CCA$tot.chi, x$CA$tot.chi,
+    chi <- c(x$tot.chi, x$pCCA$tot.chi, x$CCA$tot.chi, x$CA$tot.chi,
              x$CA$imaginary.chi)
-    ## Proportions of inertia only for Real dimensions in capscale
-    if (is.null(x$CA$imaginary.chi))
-        props <- chi/chi[1]
-    else
-        props <- c(NA, chi[-c(1, length(chi))]/chi[2], NA)
-    rnk <- c(NA, if (!is.null(x$CA$imaginary.rank)) NA, x$pCCA$rank, x$CCA$rank, x$CA$rank,
-             x$CA$imaginary.rank)
+    ## No proportion of imaginary component in capscale
+    props <- chi/chi[1]
+    if(!is.null(x$CA$imaginary.chi))
+        props[length(props)] <- NA
+    rnk <- c(NA, x$pCCA$rank, x$CCA$rank, x$CA$rank, x$CA$imaginary.rank)
     tbl <- cbind(chi, props, rnk)
     colnames(tbl) <- c("Inertia", "Proportion", "Rank")
-    rn <- c("Total", "Real Total",  "Conditional", "Constrained", "Unconstrained",
+    rn <- c("Total", "Conditional", "Constrained", "Unconstrained",
             "Imaginary")
-    rownames(tbl) <- rn[c(TRUE, !is.null(x$CA$imaginary.chi), !is.null(x$pCCA),
+    rownames(tbl) <- rn[c(TRUE,!is.null(x$pCCA),
                           !is.null(x$CCA),  !is.null(x$CA),
                           !is.null(x$CA$imaginary.chi))]
     ## Remove "Proportion" if only one component

--- a/man/capscale.Rd
+++ b/man/capscale.Rd
@@ -1,16 +1,16 @@
 \name{capscale}
 \alias{capscale}
+\alias{oldCapscale}
 
-\title{[Partial] Constrained Analysis of Principal Coordinates or
-  distance-based RDA }
+\title{[Partial] Distance-based Redundancy Analysis }
 \description{
-  Constrained Analysis of Principal Coordinates (CAP) is an ordination method
+  Distance-based redundancy analysis (dbRDA) is an ordination method
   similar to Redundancy Analysis (\code{\link{rda}}), but it allows
   non-Euclidean dissimilarity indices, such as Manhattan or
   Bray--Curtis distance. Despite this non-Euclidean feature, the analysis
   is strictly linear and metric. If called with Euclidean distance,
   the results are identical to \code{\link{rda}}, but \code{capscale}
-  will be much more inefficient. Function \code{capscale} is a
+  will be less efficient. Function \code{capscale} is a
   constrained version of metric scaling, a.k.a. principal coordinates
   analysis, which is based on the Euclidean distance but can be used,
   and is more useful, with other dissimilarity measures. The function
@@ -100,34 +100,23 @@ capscale(formula, data, distance = "euclidean", sqrt.dist = FALSE,
   just like in \code{\link{rda}} and \code{\link{cca}} so that
   ``partial'' analysis can be performed.
 
-  The current implementation  differs from the method suggested by
-  Anderson & Willis (2003) in three major points which actually make it
-  similar to distance-based redundancy analysis (Legendre & Anderson
-  1999):
-  \enumerate{
-    \item Anderson & Willis used the orthonormal solution of
-    \code{\link{cmdscale}}, whereas \code{capscale} uses axes
-    weighted by corresponding eigenvalues, so that the ordination
-    distances are the best approximations of original
-    dissimilarities. In the original method, later ``noise'' axes are
-    just as important as first major axes.
-    \item Anderson & Willis take only a subset of axes, whereas 
-    \code{capscale} uses all axes with positive eigenvalues. The use of
-    subset is necessary with orthonormal axes to chop off some
-    ``noise'', but the use of all axes guarantees that the results are
-    the best approximation of original dissimilarities.
-    \item Function \code{capscale} adds species scores as weighted sums
-    of (residual) community matrix (if the matrix is available), whereas
-    Anderson & Willis have no fixed method for adding species scores.
-  }
-  With these definitions, function \code{capscale} with Euclidean
-  distances will be identical to \code{\link{rda}} in eigenvalues and
-  in site, species and biplot scores (except for possible sign
-  reversal). 
-  However, it makes no sense to use \code{capscale} with
-  Euclidean distances, since direct use of \code{\link{rda}} is much more
-  efficient. Even with non-Euclidean dissimilarities, the
-  rest of the analysis will be metric and linear.
+  Non-Euclidean dissimilarities can produce negative eigenvalues
+  (Legendre & Anderson 1999). If negative eigenvalues are present, the
+  ordination axes and their eigenvalues will be based only on the real
+  dimensions with positive eigenvalues. The \code{\link{anova.cca}}
+  tests on the significance of axes will also be based only on
+  positive eigenvalues. However, the total inertia and
+  \code{\link{anova.cca}} tests for constraints will also include the
+  effects of imaginary axes with negative eigenvalues following
+  McArdle & Anderson (2001). If there are negative eigenvalues, the
+  function will report their sums in a separate column. If these
+  negative eigenvalues are disturbing, you can distort the
+  dissimilarities so that only non-negative eigenvalues will be
+  produced using argument \code{add = TRUE} (this argument is passed
+  to \code{\link{cmdscale}}). Alternatively, with
+  \code{sqrt.dist = TRUE}, square roots of dissimilarities will be used
+  which may help in avoiding negative eigenvalues (Legendre & Anderson
+  1999).
 
   The function can be also used to perform ordinary metric scaling
   a.k.a. principal coordinates analysis by using a formula with only a
@@ -170,29 +159,15 @@ capscale(formula, data, distance = "euclidean", sqrt.dist = FALSE,
 
 \author{ Jari Oksanen }
 
-\note{ The function produces negative eigenvalues with non-Euclidean
-  dissimilarity indices. The total inertia in the printed output
-  includes these negative eigenvalues and is therefore lower than the
-  sum of eigenvalues for real axes (McArdle & Anderson 2001). If there
-  are negative eigenvalues, the normal printed output will have a new
-  column that shows sums of eigenvalues for real axes and the sum of
-  negative eigenvalues of imaginary axes.
-
-  The ordination is based only on the real dimensions with positive
-  eigenvalues. Permutation tests with \code{\link{anova.cca}} use both
-  the real and imaginary axes.
-
-  In older version of \pkg{vegan} the total inertia and permutation tests
+\note{ The function \code{capscale} was originally developed as a
+  variant of constrained analysis of proximities (Anderson & Willis
+  2003), but these developments made it became identical to dbRDA.  In
+  older version of \pkg{vegan} the total inertia and permutation tests
   were based only on real axes, but in \pkg{vegan} 2.4-0 they also
   include the imaginary components following McArdle & Anderson
-  (2001).
-
-  If the negative eigenvalues are disturbing, you can
-  use argument \code{add = TRUE} passed to \code{\link{cmdscale}}, or,
-  preferably, a distance measure that does not cause these warnings.
-  Alternatively, after square root transformation of distances
-  (argument \code{sqrt.dist = TRUE}) many indices do not produce
-  negative eigenvalues.
+  (2001). For compatibility with the old versions of \pkg{vegan}, you
+  can use function \code{oldCapscale} to discard the effects of
+  imaginary dimensions (negative eigenvalues).
 
   The inertia is named after the dissimilarity index as defined in the
   dissimilarity data, or as \code{unknown distance} if such an

--- a/man/capscale.Rd
+++ b/man/capscale.Rd
@@ -165,24 +165,31 @@ capscale(formula, data, distance = "euclidean", sqrt.dist = FALSE,
   experiments. \emph{Ecological Monographs} 69, 1--24.
 
   Legendre, P. & Legendre, L. (2012).  \emph{Numerical Ecology}. 3rd English
-  Edition. Elsevier
+  Edition. Elsevier.
+
+  McArdle, B.H. & Anderson, M.J. (2001). Fitting multivariate models
+  to community data: a comment on distance-based redundancy
+  analysis. \emph{Ecology} 82, 290--297.
 }
+
 \author{ Jari Oksanen }
 
 \note{ The function produces negative eigenvalues with non-Euclidean
-  dissimilarity indices. The non-Euclidean component of inertia is
-  given under the title \code{Imaginary} in the printed output. The
-  \code{Total} inertia is the sum of all eigenvalues, but the sum of
-  all non-negative eigenvalues is given as \code{Real Total} (which is
-  higher than the \code{Total}). The ordination is based only on the
-  real dimensions with positive eigenvalues, and therefore the
-  proportions of inertia components only apply to the \code{Real
-  Total} and ignore the \code{Imaginary} component. Permutation tests
-  with \code{\link{anova.cca}} use only the real solution of positive
-  eigenvalues. Function \code{\link{adonis}} gives similar
-  significance tests, but it also handles the imaginary dimensions
-  (negative eigenvalues) and therefore its results may differ from
-  permutation test results of \code{capscale}.
+  dissimilarity indices. The total inertia in the printed output
+  includes these negative eigenvalues and is therefore lower than the
+  sum of eigenvalues for real axes (McArdle & Anderson 2001). If there
+  are negative eigenvalues, the normal printed output will have a new
+  column that shows sums of eigenvalues for real axes and the sum of
+  negative eigenvalues of imaginary axes.
+
+  The ordination is based only on the real dimensions with positive
+  eigenvalues. Permutation tests with \code{\link{anova.cca}} use both
+  the real and imaginary axes.
+
+  In older version of \pkg{vegan} the total inertia and permutation tests
+  were based only on real axes, but in \pkg{vegan} 2.4-0 they also
+  include the imaginary components following McArdle & Anderson
+  (2001).
 
   If the negative eigenvalues are disturbing, you can
   use argument \code{add = TRUE} passed to \code{\link{cmdscale}}, or,

--- a/man/capscale.Rd
+++ b/man/capscale.Rd
@@ -48,11 +48,9 @@ capscale(formula, data, distance = "euclidean", sqrt.dist = FALSE,
   \item{comm}{ Community data frame which will be used for finding
     species scores when the LHS of the \code{formula} was a
     dissimilarity matrix. This is not used if the LHS is a data
-    frame. If this is not supplied, the ``species scores'' are the axes
-    of initial metric scaling (\code{\link{cmdscale}}) and may be
-    confusing.}
+    frame. If this is not supplied, the ``species scores'' unavailable.}
   \item{add}{Logical indicating if an additive constant should be
-     computed, and added to the non-diagonal dissimilarities such
+     computed and added to the non-diagonal dissimilarities such
      that all eigenvalues are non-negative in the underlying
      Principal Co-ordinates Analysis (see \code{\link{cmdscale}} 
      for details). This implements \dQuote{correction method 2} of
@@ -87,22 +85,20 @@ capscale(formula, data, distance = "euclidean", sqrt.dist = FALSE,
      \code{\link{metaMDSdist}}.  }
 }
 \details{
-  Canonical Analysis of Principal Coordinates (CAP) is simply a
-  Redundancy Analysis of results of Metric (Classical) Multidimensional
-  Scaling (Anderson & Willis 2003). Function capscale uses two steps:
-  (1) it ordinates the dissimilarity matrix using
-  \code{\link{cmdscale}} and (2) analyses these results using
-  \code{\link{rda}}. If the user supplied a community data frame instead
-  of dissimilarities, the function will find the needed dissimilarity
-  matrix using \code{\link{vegdist}} with specified
-  \code{distance}. However, the method will accept dissimilarity
-  matrices from \code{\link{vegdist}}, \code{\link{dist}}, or any
-  other method producing similar matrices. The constraining variables can be
-  continuous or factors or both, they can have interaction terms,
-  or they can be transformed in the call. Moreover, there can be a
-  special term
-  \code{Condition} just like in \code{\link{rda}} and \code{\link{cca}}
-  so that ``partial'' CAP can be performed.
+
+  Function capscale uses two steps: (1) it ordinates the dissimilarity
+  matrix using \code{\link{cmdscale}} and (2) analyses the real
+  components using \code{\link{rda}}. If the user supplied a community
+  data frame instead of dissimilarities, the function will find the
+  needed dissimilarity matrix using \code{\link{vegdist}} with
+  specified \code{distance}. However, the method will accept
+  dissimilarity matrices from \code{\link{vegdist}},
+  \code{\link{dist}}, or any other method producing similar
+  matrices. The constraining variables can be continuous or factors or
+  both, they can have interaction terms, or they can be transformed in
+  the call. Moreover, there can be a special term \code{Condition}
+  just like in \code{\link{rda}} and \code{\link{cca}} so that
+  ``partial'' analysis can be performed.
 
   The current implementation  differs from the method suggested by
   Anderson & Willis (2003) in three major points which actually make it

--- a/man/cca.object.Rd
+++ b/man/cca.object.Rd
@@ -95,6 +95,9 @@
      \code{CCA} components. Only in \code{CCA}.}
     \item{\code{tot.chi}}{Total inertia or the sum of all eigenvalues of the
       component.}
+    \item{\code{real.tot.chi}}{If there are negative eigenvalues in
+      \code{\link{capscale}}, these will be included in \code{tot.chi},
+      and the sum of positive eigenvalues will be given in these items.}
     \item{\code{imaginary.chi}, \code{imaginary.rank},
      \code{imaginary.u.eig}}{The sum, rank (number) of negative
      eigenvalues and scaled site scores for imaginary axes in
@@ -128,7 +131,12 @@
       after both \code{pCCA} and \code{CCA}. In \code{\link{cca}} the
       standardization is Chi-square, and in \code{\link{rda}} centring
       and optional scaling by species standard deviations using function
-      \code{\link{scale}}.} }
+      \code{\link{scale}}.}
+     \item{\code{G}}{Gower double-centred dissimilarity matrices will be
+      returned as item \code{G} in \code{\link{capscale}},
+      and these will be used in permutation tests instead of corresponding
+      \code{Xbar} items.}
+      }
   }
 }
 

--- a/tests/vegan-tests.R
+++ b/tests/vegan-tests.R
@@ -48,7 +48,10 @@ anova(p, permutations=99)
 ## vegan 2.1-40 cannot handle missing data in next two
 ##anova(p, by="term", permutations=99)
 ##anova(p, by="margin", permutations=99)
-anova(p, by="axis", permutations=99)
+## The next will fail in vegan 2.4-0 which changes handling
+## of imaginary eigenvalues and explicitly refuses to run
+## anova(<capscale-object>, by = "axis")
+##anova(p, by="axis", permutations=99) 
 ## see that capscale can be updated and also works with 'dist' input
 dis <- vegdist(dune)
 p <- update(p, dis ~ .)
@@ -56,7 +59,7 @@ anova(p, permutations=99)
 ## vegan 2.1-40 cannot handle missing data in next two
 ##anova(p, by="term", permutations=99)
 ##anova(p, by="margin", permutations=99)
-anova(p, by="axis", permutations=99)
+##anova(p, by="axis", permutations=99) ## fails in vegan 2.4-0
 ### attach()ed data frame instead of data=
 attach(df)
 q <- cca(fla, na.action = na.omit, subset = Use != "Pasture" & spno > 7)
@@ -106,12 +109,12 @@ C <- factor(rep(c(1:5), each=6))
 
 ## partial db-RDA
 cap.model.cond <- capscale(X ~ A + B + Condition(C))
-anova(cap.model.cond, by="axis", strata=C)  # -> error pre r2287
+## anova(cap.model.cond, by="axis", strata=C)  # error stop in vegan 2.4-0
 anova(cap.model.cond, by="terms", strata=C)  # -> error pre r2287
 
 ## db-RDA without conditional factor
 cap.model <- capscale(X ~ A + B)
-anova(cap.model, by="axis", strata=C)  # -> no error
+## anova(cap.model, by="axis", strata=C)  # error stop in vegan 2.4-0
 anova(cap.model, by="terms", strata=C)  # -> no error
 
 # partial RDA

--- a/tests/vegan-tests.R
+++ b/tests/vegan-tests.R
@@ -48,10 +48,7 @@ anova(p, permutations=99)
 ## vegan 2.1-40 cannot handle missing data in next two
 ##anova(p, by="term", permutations=99)
 ##anova(p, by="margin", permutations=99)
-## The next will fail in vegan 2.4-0 which changes handling
-## of imaginary eigenvalues and explicitly refuses to run
-## anova(<capscale-object>, by = "axis")
-##anova(p, by="axis", permutations=99) 
+anova(p, by="axis", permutations=99)
 ## see that capscale can be updated and also works with 'dist' input
 dis <- vegdist(dune)
 p <- update(p, dis ~ .)
@@ -59,7 +56,7 @@ anova(p, permutations=99)
 ## vegan 2.1-40 cannot handle missing data in next two
 ##anova(p, by="term", permutations=99)
 ##anova(p, by="margin", permutations=99)
-##anova(p, by="axis", permutations=99) ## fails in vegan 2.4-0
+anova(p, by="axis", permutations=99)
 ### attach()ed data frame instead of data=
 attach(df)
 q <- cca(fla, na.action = na.omit, subset = Use != "Pasture" & spno > 7)
@@ -109,12 +106,12 @@ C <- factor(rep(c(1:5), each=6))
 
 ## partial db-RDA
 cap.model.cond <- capscale(X ~ A + B + Condition(C))
-## anova(cap.model.cond, by="axis", strata=C)  # error stop in vegan 2.4-0
+anova(cap.model.cond, by="axis", strata=C)  # -> error pre r2287
 anova(cap.model.cond, by="terms", strata=C)  # -> error pre r2287
 
 ## db-RDA without conditional factor
 cap.model <- capscale(X ~ A + B)
-## anova(cap.model, by="axis", strata=C)  # error stop in vegan 2.4-0
+anova(cap.model, by="axis", strata=C)  # -> no error
 anova(cap.model, by="terms", strata=C)  # -> no error
 
 # partial RDA

--- a/tests/vegan-tests.Rout.save
+++ b/tests/vegan-tests.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2015-02-26 r67895) -- "Unsuffered Consequences"
+R version 3.2.1 (2015-06-18) -- "World-Famous Astronaut"
 Copyright (C) 2015 The R Foundation for Statistical Computing
-Platform: x86_64-unknown-linux-gnu (64-bit)
+Platform: x86_64-apple-darwin10.8.0 (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -101,23 +101,10 @@ Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > ## vegan 2.1-40 cannot handle missing data in next two
 > ##anova(p, by="term", permutations=99)
 > ##anova(p, by="margin", permutations=99)
-> anova(p, by="axis", permutations=99)
-Permutation test for capscale under reduced model
-Marginal tests for axes
-Permutation: free
-Number of permutations: 99
-
-Model: capscale(formula = dune ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = object$subset)
-         Df Variance      F Pr(>F)  
-CAP1      1  25.0252 4.1487   0.03 *
-CAP2      1  15.8759 2.6319   0.07 .
-CAP3      1   8.0942 1.3419   0.25  
-CAP4      1   5.0675 0.8401   0.64  
-CAP5      1   3.5671 0.5914   0.85  
-CAP6      1   1.9520 0.3236   0.96  
-Residual  5  30.1605                
----
-Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+> ## The next will fail in vegan 2.4-0 which changes handling
+> ## of imaginary eigenvalues and explicitly refuses to run
+> ## anova(<capscale-object>, by = "axis")
+> ##anova(p, by="axis", permutations=99) 
 > ## see that capscale can be updated and also works with 'dist' input
 > dis <- vegdist(dune)
 > p <- update(p, dis ~ .)
@@ -128,28 +115,12 @@ Number of permutations: 99
 
 Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = Use != "Pasture" & spno > 7)
          Df Variance      F Pr(>F)
-Model     6  1.54840 1.6423   0.11
-Residual  5  0.78568              
+Model     6  1.52798 1.6548   0.11
+Residual  5  0.76948              
 > ## vegan 2.1-40 cannot handle missing data in next two
 > ##anova(p, by="term", permutations=99)
 > ##anova(p, by="margin", permutations=99)
-> anova(p, by="axis", permutations=99)
-Permutation test for capscale under reduced model
-Marginal tests for axes
-Permutation: free
-Number of permutations: 99
-
-Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = object$subset)
-         Df Variance      F Pr(>F)  
-CAP1      1  0.77834 4.9533   0.02 *
-CAP2      1  0.45691 2.9078   0.03 *
-CAP3      1  0.14701 0.9355   0.51  
-CAP4      1  0.11879 0.7560   0.65  
-CAP5      1  0.04213 0.2681   0.94  
-CAP6      1  0.00522 0.0332   1.00  
-Residual  5  0.78568                
----
-Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+> ##anova(p, by="axis", permutations=99) ## fails in vegan 2.4-0
 > ### attach()ed data frame instead of data=
 > attach(df)
 > q <- cca(fla, na.action = na.omit, subset = Use != "Pasture" & spno > 7)
@@ -160,7 +131,7 @@ Number of permutations: 99
 
 Model: cca(formula = dune ~ Management + poly(A1, 2) + spno, na.action = na.omit, subset = Use != "Pasture" & spno > 7)
          Df ChiSquare      F Pr(>F)
-Model     6   1.25838 1.3106   0.12
+Model     6   1.25838 1.3106   0.11
 Residual  5   0.80011              
 > ## commented tests below fail in vegan 2.1-40 because number of
 > ## observations changes
@@ -175,11 +146,11 @@ Number of permutations: 99
 Model: cca(formula = dune ~ Management + poly(A1, 2) + spno, na.action = na.omit, subset = object$subset)
          Df ChiSquare      F Pr(>F)  
 CCA1      1   0.46993 2.9366   0.03 *
-CCA2      1   0.26217 1.6384   0.20  
+CCA2      1   0.26217 1.6384   0.13  
 CCA3      1   0.19308 1.2066   0.34  
-CCA4      1   0.18345 1.1464   0.33  
-CCA5      1   0.08871 0.5544   0.69  
-CCA6      1   0.06104 0.3815   0.89  
+CCA4      1   0.18345 1.1464   0.42  
+CCA5      1   0.08871 0.5544   0.75  
+CCA6      1   0.06104 0.3815   0.94  
 Residual  5   0.80011                
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
@@ -253,12 +224,11 @@ Eigenvalues for unconstrained axes:
 > foo("capscale", vegdist(dune), Management, na.action = na.omit)
 Call: bar(formula = Y ~ X, na.action = ..1)
 
-              Inertia Proportion Rank
-Total           3.765                
-Real Total      3.949      1.000     
-Constrained     1.446      0.366    3
-Unconstrained   2.504      0.634   13
-Imaginary      -0.184               4
+              Inertia Proportion Eigenvals Rank
+Total          3.7650     1.0000    3.9490     
+Constrained    1.4180     0.3766    1.4460    3
+Unconstrained  2.3470     0.6234    2.5040   13
+Imaginary                          -0.1840    4
 Inertia is squared Bray distance 
 2 observations deleted due to missingness 
 
@@ -324,10 +294,10 @@ Number of permutations: 99
 
 Model: cca(formula = dune ~ A1 + Moisture + Condition(Management), data = dune.env, subset = object$subset)
          Df ChiSquare      F Pr(>F)  
-CCA1      1   0.27109 2.9561   0.04 *
-CCA2      1   0.14057 1.5329   0.21  
-CCA3      1   0.08761 0.9553   0.72  
-CCA4      1   0.05624 0.6132   0.97  
+CCA1      1   0.27109 2.9561   0.02 *
+CCA2      1   0.14057 1.5329   0.29  
+CCA3      1   0.08761 0.9553   0.74  
+CCA4      1   0.05624 0.6132   0.92  
 Residual 10   0.91705                
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
@@ -354,19 +324,7 @@ Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > 
 > ## partial db-RDA
 > cap.model.cond <- capscale(X ~ A + B + Condition(C))
-> anova(cap.model.cond, by="axis", strata=C)  # -> error pre r2287
-Permutation test for capscale under reduced model
-Marginal tests for axes
-Blocks:  strata 
-Permutation: free
-Number of permutations: 999
-
-Model: capscale(formula = X ~ A + B + Condition(C))
-         Df Variance      F Pr(>F)
-CAP1      1   0.2682 1.3075  0.242
-CAP2      1   0.0685 0.3339  0.921
-CAP3      1   0.0455 0.2217  0.966
-Residual 22   4.5130              
+> ## anova(cap.model.cond, by="axis", strata=C)  # error stop in vegan 2.4-0
 > anova(cap.model.cond, by="terms", strata=C)  # -> error pre r2287
 Permutation test for capscale under reduced model
 Terms added sequentially (first to last)
@@ -376,25 +334,13 @@ Number of permutations: 999
 
 Model: capscale(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6415  0.680
-B         2   0.2506 0.6108  0.824
+A         1   0.1316 0.6415  0.677
+B         2   0.2506 0.6108  0.828
 Residual 22   4.5130              
 > 
 > ## db-RDA without conditional factor
 > cap.model <- capscale(X ~ A + B)
-> anova(cap.model, by="axis", strata=C)  # -> no error
-Permutation test for capscale under reduced model
-Marginal tests for axes
-Blocks:  strata 
-Permutation: free
-Number of permutations: 999
-
-Model: capscale(formula = X ~ A + B)
-         Df Variance      F Pr(>F)
-CAP1      1   0.2682 1.3267  0.240
-CAP2      1   0.0685 0.3388  0.913
-CAP3      1   0.0455 0.2249  0.964
-Residual 26   5.2565              
+> ## anova(cap.model, by="axis", strata=C)  # error stop in vegan 2.4-0
 > anova(cap.model, by="terms", strata=C)  # -> no error
 Permutation test for capscale under reduced model
 Terms added sequentially (first to last)
@@ -404,8 +350,8 @@ Number of permutations: 999
 
 Model: capscale(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6509  0.693
-B         2   0.2506 0.6198  0.829
+A         1   0.1316 0.6509  0.677
+B         2   0.2506 0.6198  0.823
 Residual 26   5.2565              
 > 
 > # partial RDA
@@ -419,9 +365,9 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-RDA1      1   0.2682 1.3075  0.286
-RDA2      1   0.0685 0.3339  0.921
-RDA3      1   0.0455 0.2217  0.963
+RDA1      1   0.2682 1.3075  0.240
+RDA2      1   0.0685 0.3339  0.913
+RDA3      1   0.0455 0.2217  0.964
 Residual 22   4.5130              
 > anova(rda.model.cond, by="terms", strata=C)  # -> error pre r2287
 Permutation test for rda under reduced model
@@ -432,8 +378,8 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6415  0.669
-B         2   0.2506 0.6108  0.827
+A         1   0.1316 0.6415  0.693
+B         2   0.2506 0.6108  0.831
 Residual 22   4.5130              
 > 
 > # RDA without conditional factor
@@ -447,9 +393,9 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-RDA1      1   0.2682 1.3267  0.258
-RDA2      1   0.0685 0.3388  0.898
-RDA3      1   0.0455 0.2249  0.971
+RDA1      1   0.2682 1.3267  0.286
+RDA2      1   0.0685 0.3388  0.921
+RDA3      1   0.0455 0.2249  0.963
 Residual 26   5.2565              
 > anova(rda.model, by="terms", strata=C)  # -> no error
 Permutation test for rda under reduced model
@@ -460,8 +406,8 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6509  0.695
-B         2   0.2506 0.6198  0.820
+A         1   0.1316 0.6509  0.665
+B         2   0.2506 0.6198  0.827
 Residual 26   5.2565              
 > ## clean.up
 > rm(X, A, B, C, cap.model.cond, cap.model, rda.model.cond, rda.model)
@@ -657,4 +603,4 @@ Number of permutations: 99
 > 
 > proc.time()
    user  system elapsed 
-  7.769   0.040   7.797 
+ 28.003   0.464  28.512 

--- a/tests/vegan-tests.Rout.save
+++ b/tests/vegan-tests.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2015-02-26 r67895) -- "Unsuffered Consequences"
+R Under development (unstable) (2015-08-10 r68987) -- "Unsuffered Consequences"
 Copyright (C) 2015 The R Foundation for Statistical Computing
-Platform: x86_64-unknown-linux-gnu (64-bit)
+Platform: x86_64-pc-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -111,10 +111,10 @@ Model: capscale(formula = dune ~ Management + poly(A1, 2) + spno, data = df, na.
          Df Variance      F Pr(>F)  
 CAP1      1  25.0252 4.1487   0.03 *
 CAP2      1  15.8759 2.6319   0.07 .
-CAP3      1   8.0942 1.3419   0.25  
-CAP4      1   5.0675 0.8401   0.64  
-CAP5      1   3.5671 0.5914   0.85  
-CAP6      1   1.9520 0.3236   0.96  
+CAP3      1   8.0942 1.3419   0.27  
+CAP4      1   5.0675 0.8401   0.62  
+CAP5      1   3.5671 0.5914   0.76  
+CAP6      1   1.9520 0.3236   0.89  
 Residual  5  30.1605                
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
@@ -128,26 +128,27 @@ Number of permutations: 99
 
 Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = Use != "Pasture" & spno > 7)
          Df Variance      F Pr(>F)
-Model     6  1.54840 1.6423   0.11
-Residual  5  0.78568              
+Model     6  1.52798 1.6548   0.11
+Residual  5  0.76948              
 > ## vegan 2.1-40 cannot handle missing data in next two
 > ##anova(p, by="term", permutations=99)
 > ##anova(p, by="margin", permutations=99)
 > anova(p, by="axis", permutations=99)
+imaginary variation was discarded
 Permutation test for capscale under reduced model
 Marginal tests for axes
 Permutation: free
 Number of permutations: 99
 
 Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = object$subset)
-         Df Variance      F Pr(>F)  
-CAP1      1  0.77834 4.9533   0.02 *
-CAP2      1  0.45691 2.9078   0.03 *
-CAP3      1  0.14701 0.9355   0.51  
-CAP4      1  0.11879 0.7560   0.65  
-CAP5      1  0.04213 0.2681   0.94  
-CAP6      1  0.00522 0.0332   1.00  
-Residual  5  0.78568                
+         Df Variance      F Pr(>F)   
+CAP1      1  0.77834 4.9533   0.01 **
+CAP2      1  0.45691 2.9078   0.03 * 
+CAP3      1  0.14701 0.9355   0.54   
+CAP4      1  0.11879 0.7560   0.59   
+CAP5      1  0.04213 0.2681   0.87   
+CAP6      1  0.00522 0.0332   0.91   
+Residual  5  0.76948                 
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > ### attach()ed data frame instead of data=
@@ -253,12 +254,11 @@ Eigenvalues for unconstrained axes:
 > foo("capscale", vegdist(dune), Management, na.action = na.omit)
 Call: bar(formula = Y ~ X, na.action = ..1)
 
-              Inertia Proportion Rank
-Total           3.765                
-Real Total      3.949      1.000     
-Constrained     1.446      0.366    3
-Unconstrained   2.504      0.634   13
-Imaginary      -0.184               4
+              Inertia Proportion Eigenvals Rank
+Total          3.7650     1.0000    3.9490     
+Constrained    1.4180     0.3766    1.4460    3
+Unconstrained  2.3470     0.6234    2.5040   13
+Imaginary                          -0.1840    4
 Inertia is squared Bray distance 
 2 observations deleted due to missingness 
 
@@ -363,9 +363,9 @@ Number of permutations: 999
 
 Model: capscale(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-CAP1      1   0.2682 1.3075  0.242
-CAP2      1   0.0685 0.3339  0.921
-CAP3      1   0.0455 0.2217  0.966
+CAP1      1   0.2682 1.3075  0.244
+CAP2      1   0.0685 0.3339  0.911
+CAP3      1   0.0455 0.2217  0.963
 Residual 22   4.5130              
 > anova(cap.model.cond, by="terms", strata=C)  # -> error pre r2287
 Permutation test for capscale under reduced model
@@ -391,9 +391,9 @@ Number of permutations: 999
 
 Model: capscale(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-CAP1      1   0.2682 1.3267  0.240
-CAP2      1   0.0685 0.3388  0.913
-CAP3      1   0.0455 0.2249  0.964
+CAP1      1   0.2682 1.3267  0.241
+CAP2      1   0.0685 0.3388  0.908
+CAP3      1   0.0455 0.2249  0.961
 Residual 26   5.2565              
 > anova(cap.model, by="terms", strata=C)  # -> no error
 Permutation test for capscale under reduced model
@@ -657,4 +657,4 @@ Number of permutations: 99
 > 
 > proc.time()
    user  system elapsed 
-  7.769   0.040   7.797 
+  8.964   0.036   8.993 

--- a/tests/vegan-tests.Rout.save
+++ b/tests/vegan-tests.Rout.save
@@ -1,7 +1,7 @@
 
-R version 3.2.1 (2015-06-18) -- "World-Famous Astronaut"
+R Under development (unstable) (2015-02-26 r67895) -- "Unsuffered Consequences"
 Copyright (C) 2015 The R Foundation for Statistical Computing
-Platform: x86_64-apple-darwin10.8.0 (64-bit)
+Platform: x86_64-unknown-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -101,10 +101,23 @@ Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > ## vegan 2.1-40 cannot handle missing data in next two
 > ##anova(p, by="term", permutations=99)
 > ##anova(p, by="margin", permutations=99)
-> ## The next will fail in vegan 2.4-0 which changes handling
-> ## of imaginary eigenvalues and explicitly refuses to run
-> ## anova(<capscale-object>, by = "axis")
-> ##anova(p, by="axis", permutations=99) 
+> anova(p, by="axis", permutations=99)
+Permutation test for capscale under reduced model
+Marginal tests for axes
+Permutation: free
+Number of permutations: 99
+
+Model: capscale(formula = dune ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = object$subset)
+         Df Variance      F Pr(>F)  
+CAP1      1  25.0252 4.1487   0.03 *
+CAP2      1  15.8759 2.6319   0.07 .
+CAP3      1   8.0942 1.3419   0.25  
+CAP4      1   5.0675 0.8401   0.64  
+CAP5      1   3.5671 0.5914   0.85  
+CAP6      1   1.9520 0.3236   0.96  
+Residual  5  30.1605                
+---
+Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > ## see that capscale can be updated and also works with 'dist' input
 > dis <- vegdist(dune)
 > p <- update(p, dis ~ .)
@@ -115,12 +128,28 @@ Number of permutations: 99
 
 Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = Use != "Pasture" & spno > 7)
          Df Variance      F Pr(>F)
-Model     6  1.52798 1.6548   0.11
-Residual  5  0.76948              
+Model     6  1.54840 1.6423   0.11
+Residual  5  0.78568              
 > ## vegan 2.1-40 cannot handle missing data in next two
 > ##anova(p, by="term", permutations=99)
 > ##anova(p, by="margin", permutations=99)
-> ##anova(p, by="axis", permutations=99) ## fails in vegan 2.4-0
+> anova(p, by="axis", permutations=99)
+Permutation test for capscale under reduced model
+Marginal tests for axes
+Permutation: free
+Number of permutations: 99
+
+Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = object$subset)
+         Df Variance      F Pr(>F)  
+CAP1      1  0.77834 4.9533   0.02 *
+CAP2      1  0.45691 2.9078   0.03 *
+CAP3      1  0.14701 0.9355   0.51  
+CAP4      1  0.11879 0.7560   0.65  
+CAP5      1  0.04213 0.2681   0.94  
+CAP6      1  0.00522 0.0332   1.00  
+Residual  5  0.78568                
+---
+Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > ### attach()ed data frame instead of data=
 > attach(df)
 > q <- cca(fla, na.action = na.omit, subset = Use != "Pasture" & spno > 7)
@@ -131,7 +160,7 @@ Number of permutations: 99
 
 Model: cca(formula = dune ~ Management + poly(A1, 2) + spno, na.action = na.omit, subset = Use != "Pasture" & spno > 7)
          Df ChiSquare      F Pr(>F)
-Model     6   1.25838 1.3106   0.11
+Model     6   1.25838 1.3106   0.12
 Residual  5   0.80011              
 > ## commented tests below fail in vegan 2.1-40 because number of
 > ## observations changes
@@ -146,11 +175,11 @@ Number of permutations: 99
 Model: cca(formula = dune ~ Management + poly(A1, 2) + spno, na.action = na.omit, subset = object$subset)
          Df ChiSquare      F Pr(>F)  
 CCA1      1   0.46993 2.9366   0.03 *
-CCA2      1   0.26217 1.6384   0.13  
+CCA2      1   0.26217 1.6384   0.20  
 CCA3      1   0.19308 1.2066   0.34  
-CCA4      1   0.18345 1.1464   0.42  
-CCA5      1   0.08871 0.5544   0.75  
-CCA6      1   0.06104 0.3815   0.94  
+CCA4      1   0.18345 1.1464   0.33  
+CCA5      1   0.08871 0.5544   0.69  
+CCA6      1   0.06104 0.3815   0.89  
 Residual  5   0.80011                
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
@@ -224,11 +253,12 @@ Eigenvalues for unconstrained axes:
 > foo("capscale", vegdist(dune), Management, na.action = na.omit)
 Call: bar(formula = Y ~ X, na.action = ..1)
 
-              Inertia Proportion Eigenvals Rank
-Total          3.7650     1.0000    3.9490     
-Constrained    1.4180     0.3766    1.4460    3
-Unconstrained  2.3470     0.6234    2.5040   13
-Imaginary                          -0.1840    4
+              Inertia Proportion Rank
+Total           3.765                
+Real Total      3.949      1.000     
+Constrained     1.446      0.366    3
+Unconstrained   2.504      0.634   13
+Imaginary      -0.184               4
 Inertia is squared Bray distance 
 2 observations deleted due to missingness 
 
@@ -294,10 +324,10 @@ Number of permutations: 99
 
 Model: cca(formula = dune ~ A1 + Moisture + Condition(Management), data = dune.env, subset = object$subset)
          Df ChiSquare      F Pr(>F)  
-CCA1      1   0.27109 2.9561   0.02 *
-CCA2      1   0.14057 1.5329   0.29  
-CCA3      1   0.08761 0.9553   0.74  
-CCA4      1   0.05624 0.6132   0.92  
+CCA1      1   0.27109 2.9561   0.04 *
+CCA2      1   0.14057 1.5329   0.21  
+CCA3      1   0.08761 0.9553   0.72  
+CCA4      1   0.05624 0.6132   0.97  
 Residual 10   0.91705                
 ---
 Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
@@ -324,7 +354,19 @@ Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
 > 
 > ## partial db-RDA
 > cap.model.cond <- capscale(X ~ A + B + Condition(C))
-> ## anova(cap.model.cond, by="axis", strata=C)  # error stop in vegan 2.4-0
+> anova(cap.model.cond, by="axis", strata=C)  # -> error pre r2287
+Permutation test for capscale under reduced model
+Marginal tests for axes
+Blocks:  strata 
+Permutation: free
+Number of permutations: 999
+
+Model: capscale(formula = X ~ A + B + Condition(C))
+         Df Variance      F Pr(>F)
+CAP1      1   0.2682 1.3075  0.242
+CAP2      1   0.0685 0.3339  0.921
+CAP3      1   0.0455 0.2217  0.966
+Residual 22   4.5130              
 > anova(cap.model.cond, by="terms", strata=C)  # -> error pre r2287
 Permutation test for capscale under reduced model
 Terms added sequentially (first to last)
@@ -334,13 +376,25 @@ Number of permutations: 999
 
 Model: capscale(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6415  0.677
-B         2   0.2506 0.6108  0.828
+A         1   0.1316 0.6415  0.680
+B         2   0.2506 0.6108  0.824
 Residual 22   4.5130              
 > 
 > ## db-RDA without conditional factor
 > cap.model <- capscale(X ~ A + B)
-> ## anova(cap.model, by="axis", strata=C)  # error stop in vegan 2.4-0
+> anova(cap.model, by="axis", strata=C)  # -> no error
+Permutation test for capscale under reduced model
+Marginal tests for axes
+Blocks:  strata 
+Permutation: free
+Number of permutations: 999
+
+Model: capscale(formula = X ~ A + B)
+         Df Variance      F Pr(>F)
+CAP1      1   0.2682 1.3267  0.240
+CAP2      1   0.0685 0.3388  0.913
+CAP3      1   0.0455 0.2249  0.964
+Residual 26   5.2565              
 > anova(cap.model, by="terms", strata=C)  # -> no error
 Permutation test for capscale under reduced model
 Terms added sequentially (first to last)
@@ -350,8 +404,8 @@ Number of permutations: 999
 
 Model: capscale(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6509  0.677
-B         2   0.2506 0.6198  0.823
+A         1   0.1316 0.6509  0.693
+B         2   0.2506 0.6198  0.829
 Residual 26   5.2565              
 > 
 > # partial RDA
@@ -365,9 +419,9 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-RDA1      1   0.2682 1.3075  0.240
-RDA2      1   0.0685 0.3339  0.913
-RDA3      1   0.0455 0.2217  0.964
+RDA1      1   0.2682 1.3075  0.286
+RDA2      1   0.0685 0.3339  0.921
+RDA3      1   0.0455 0.2217  0.963
 Residual 22   4.5130              
 > anova(rda.model.cond, by="terms", strata=C)  # -> error pre r2287
 Permutation test for rda under reduced model
@@ -378,8 +432,8 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B + Condition(C))
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6415  0.693
-B         2   0.2506 0.6108  0.831
+A         1   0.1316 0.6415  0.669
+B         2   0.2506 0.6108  0.827
 Residual 22   4.5130              
 > 
 > # RDA without conditional factor
@@ -393,9 +447,9 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-RDA1      1   0.2682 1.3267  0.286
-RDA2      1   0.0685 0.3388  0.921
-RDA3      1   0.0455 0.2249  0.963
+RDA1      1   0.2682 1.3267  0.258
+RDA2      1   0.0685 0.3388  0.898
+RDA3      1   0.0455 0.2249  0.971
 Residual 26   5.2565              
 > anova(rda.model, by="terms", strata=C)  # -> no error
 Permutation test for rda under reduced model
@@ -406,8 +460,8 @@ Number of permutations: 999
 
 Model: rda(formula = X ~ A + B)
          Df Variance      F Pr(>F)
-A         1   0.1316 0.6509  0.665
-B         2   0.2506 0.6198  0.827
+A         1   0.1316 0.6509  0.695
+B         2   0.2506 0.6198  0.820
 Residual 26   5.2565              
 > ## clean.up
 > rm(X, A, B, C, cap.model.cond, cap.model, rda.model.cond, rda.model)
@@ -603,4 +657,4 @@ Number of permutations: 99
 > 
 > proc.time()
    user  system elapsed 
- 28.003   0.464  28.512 
+  7.769   0.040   7.797 


### PR DESCRIPTION
This PR was triggered by @legendre who wrote dbRDA to handle negative eigenvalues. Instead of nw quick functions, this PR changes `capscale` so that imaginary components (negative eigenvalues) are taken into account in total inertia in partial, constrained and residual components. Earlier we only gave real part of these components and the negative components were only given for the overall model. The PR follows 

McArdle, B.H. & Anderson, M.J. (2001). Fitting multivariate models
     to community data: a comment on distance-based redundancy
     analysis. *Ecology* **82,** 290-297.

New `print`ed output will give the components and their proportions and add a new column of sum of eigenvalues for partitions and the sum of negative eigenvalues when needed:
```
              Inertia Proportion Eigenvals Rank
Total          4.2990     1.0000    4.5940     
Constrained    1.4690     0.3416    1.5000    3
Unconstrained  2.8300     0.6584    3.0940   14
Imaginary                          -0.2950    5
Inertia is squared Bray distance 
```

The permutation tests in `permutest.cca` also change: in `capscale` they will now permute Gower transformed dissimilarity matrix instead of raw data. The results will now be identical to `adonis` when the same permutation matrix is used. When Euclidean distances are used, `capscale`, `rda` and `adonis` will give identical results -- although internal implementations are very different. BTW, I think `adonis` could be much simplified using the same pattern as `capscale`.

Now `RsquareAdj.rda` works for `capscale` and separete `RsquareAdj.capscale` function was removed (that function refused to give *R*^2 when there were negative eigenvalues).