### PR TITLE
Distance partition in varpart

### DIFF
--- a/R/GowerDblcen.R
+++ b/R/GowerDblcen.R
@@ -1,0 +1,13 @@
+### Internal function for double centring of a *matrix* of
+### dissimilarities. We used .C("dblcen", ..., PACKAGE = "stats")
+### which does not dublicate its argument, but it was removed from R
+### in r60360 | ripley | 2012-08-22 07:59:00 UTC (Wed, 22 Aug 2012)
+### "more conversion to .Call, clean up". Input 'x' *must* be a
+### matrix. This was originally an internal function in betadisper.R
+### (commit 7cbd4529 Thu Aug 23 08:45:31 2012 +0000)
+GowerDblcen <- function(x, na.rm = TRUE) {
+    cnt <- colMeans(x, na.rm = na.rm)
+    x <- sweep(x, 2L, cnt, check.margin = FALSE)
+    cnt <- rowMeans(x, na.rm = na.rm)
+    sweep(x, 1L, cnt, check.margin = FALSE)
+}

--- a/R/print.varpart.R
+++ b/R/print.varpart.R
@@ -1,7 +1,7 @@
-"print.varpart" <-
-function (x, ...)
+`print.varpart` <-
+    function (x, ...)
 {
-    cat("\nPartition of variation in RDA\n\n")
+    cat("\nPartition of", x$inert, "in", x$RDA, "\n\n")
     writeLines(strwrap(pasteCall(x$call)))
     if (x$scale)
         cat("Columns of Y were scaled to unit variance\n")

--- a/R/print.varpart234.R
+++ b/R/print.varpart234.R
@@ -1,9 +1,10 @@
-"print.varpart234" <-
-function(x, digits = 5, ...)
+`print.varpart234` <-
+    function(x, digits = 5, ...)
 {
     cat("No. of explanatory tables:", x$nsets, "\n")
     cat("Total variation (SS):", format(x$SS.Y, digits=digits), "\n")
-    cat("            Variance:", format(x$SS.Y/(x$n-1), digits=digits), "\n")
+    if (x$ordination == "rda")
+        cat("            Variance:", format(x$SS.Y/(x$n-1), digits=digits), "\n")
     cat("No. of observations:",  x$n, "\n")
     cat("\nPartition table:\n")
     out <- rbind(x$fract, "Individual fractions" = NA, x$indfract)
@@ -14,7 +15,8 @@ function(x, digits = 5, ...)
     out[,2:3] <- round(out[,2:3], digits=digits)
     out[,1:4] <- sapply(out[,1:4], function(x) gsub("NA", "  ", format(x, digits=digits)))
     print(out)
-    cat("---\nUse function 'rda' to test significance of fractions of interest\n")
+    cat("---\nUse function", sQuote(x$ordination),
+        "to test significance of fractions of interest\n")
     if (!is.null(x$bigwarning))
         for (i in seq_along(x$bigwarning))
             warning("collinearity detected: redundant variable(s)  between tables ",

--- a/R/simpleRDA2.R
+++ b/R/simpleRDA2.R
@@ -1,5 +1,7 @@
-"simpleRDA2" <-
-function (Y, X, SS.Y, ...)
+### An internal function used in varpart(): Returns only the raw
+### Rsquare and the rank of constraints in RDA.
+`simpleRDA2` <-
+    function (Y, X, SS.Y, ...)
 {
     Q <- qr(X, tol=1e-6)
     Yfit.X <- qr.fitted(Q, Y)
@@ -9,3 +11,16 @@ function (Y, X, SS.Y, ...)
     list(Rsquare = Rsquare, m = Q$rank)
 }
 
+### Analogous function, but the input must be Gower double-centred
+### dissimilarities 'G = -GowerDblcen(as.matrix(dist(Y)))/2'. The math
+### is based on McArdle & Anderson, Ecology 82: 290-297 (2001).
+`simpleDBRDA` <-
+    function(G, X, SS.G, ...)
+{
+    Q <- qr(X, tol=1e-6)
+    Yfit.X <- qr.fitted(Q, G)
+    SS <- sum(diag(Yfit.X))
+    if (missing(SS.G)) SS.G <- sum(diag(G))
+    Rsquare <- SS/SS.G
+    list(Rsquare = Rsquare, m = Q$rank)
+}

--- a/R/simpleRDA2.R
+++ b/R/simpleRDA2.R
@@ -12,7 +12,7 @@
 }
 
 ### Analogous function, but the input must be Gower double-centred
-### dissimilarities 'G = -GowerDblcen(as.matrix(dist(Y^2)))/2'. The
+### dissimilarities 'G = -GowerDblcen(as.matrix(dist(Y)^2))/2'. The
 ### math is based on McArdle & Anderson, Ecology 82: 290-297 (2001).
 `simpleDBRDA` <-
     function(G, X, SS.G, ...)

--- a/R/simpleRDA2.R
+++ b/R/simpleRDA2.R
@@ -12,8 +12,8 @@
 }
 
 ### Analogous function, but the input must be Gower double-centred
-### dissimilarities 'G = -GowerDblcen(as.matrix(dist(Y)))/2'. The math
-### is based on McArdle & Anderson, Ecology 82: 290-297 (2001).
+### dissimilarities 'G = -GowerDblcen(as.matrix(dist(Y^2)))/2'. The
+### math is based on McArdle & Anderson, Ecology 82: 290-297 (2001).
 `simpleDBRDA` <-
     function(G, X, SS.G, ...)
 {

--- a/R/varpart.R
+++ b/R/varpart.R
@@ -8,9 +8,15 @@
         stop("needs 2 to 4 explanatory tables")
     ## transfo and scale can be used only with non-distance data
     if (inherits(Y, "dist")) {
+        inert <- attr(Y, "method")
+        inert <- paste0(toupper(substring(inert, 1, 1)), substring(inert, 2))
+        inert <- paste("squared", inert, "distance")
+        RDA <- "dbRDA"
         if(!missing(transfo) || !missing(scale))
             message("arguments 'transfo' and 'scale' are ignored with distances")
     } else {
+        inert <- "variance"
+        RDA <- "RDA"
         if (!missing(transfo)) {
             Y <- decostand(Y, transfo)
             transfo <- attr(Y, "decostand")
@@ -41,9 +47,15 @@
                        varpart2(Y, Sets[[1]], Sets[[2]]),
                        varpart3(Y, Sets[[1]], Sets[[2]], Sets[[3]]),
                        varpart4(Y, Sets[[1]], Sets[[2]], Sets[[3]], Sets[[4]]))
+    if (inherits(Y, "dist"))
+        out$part$ordination <- "capscale"
+    else
+        out$part$ordination <- "rda"
     out$scale <- scale
     if (!missing(transfo))
         out$transfo <- transfo
+    out$inert <- inert
+    out$RDA <- RDA
     out$call <- match.call()
     mx <- rep(" ", length(X))
     for (i in seq_along(X)) mx[i] <- deparse(out$call[[i+2]], width.cutoff = 500)

--- a/R/varpart.R
+++ b/R/varpart.R
@@ -6,15 +6,21 @@
     X <- list(X, ...)
     if ((length(X) < 2 || length(X) > 4))
         stop("needs 2 to 4 explanatory tables")
-    if (!missing(transfo)) {
-        Y <- decostand(Y, transfo)
-        transfo <- attr(Y, "decostand")
+    ## transfo and scale can be used only with non-distance data
+    if (inherits(Y, "dist")) {
+        if(!missing(transfo) || !missing(scale))
+            message("arguments 'transfo' and 'scale' are ignored with distances")
+    } else {
+        if (!missing(transfo)) {
+            Y <- decostand(Y, transfo)
+            transfo <- attr(Y, "decostand")
+        }
+        if (!missing(transfo) && (is.null(dim(Y)) || ncol(Y) == 1))
+            warning("Transformations probably are meaningless to a single variable")
+        if (scale && !missing(transfo))
+            warning("Y should not be both transformed and scaled (standardized)")
+        Y <- scale(Y, center = TRUE, scale = scale)
     }
-    if (!missing(transfo) && (is.null(dim(Y)) || ncol(Y) == 1))
-        warning("Transformations probably are meaningless to a single variable")
-    if (scale && !missing(transfo))
-        warning("Y should not be both transformed and scaled (standardized)")
-    Y <- scale(Y, center = TRUE, scale = scale)
     Sets <- list()
     for (i in seq_along(X)) {
         if (inherits(X[[i]], "formula")) {

--- a/R/varpart.R
+++ b/R/varpart.R
@@ -9,7 +9,6 @@
     ## transfo and scale can be used only with non-distance data
     if (inherits(Y, "dist")) {
         inert <- attr(Y, "method")
-        inert <- paste0(toupper(substring(inert, 1, 1)), substring(inert, 2))
         inert <- paste("squared", inert, "distance")
         RDA <- "dbRDA"
         if(!missing(transfo) || !missing(scale))

--- a/R/varpart2.R
+++ b/R/varpart2.R
@@ -1,7 +1,16 @@
-"varpart2" <-
+`varpart2` <-
     function (Y, X1, X2) 
 {
-    Y <- as.matrix(Y)
+    if (inherits(Y, "dist")) {
+        Y <- GowerDblcen(as.matrix(Y^2), na.rm = FALSE)
+        Y <- -Y/2
+        SS.Y <- sum(diag(Y))
+        simpleRDA2 <- match.fun(simpleDBRDA)
+    } else {
+        Y <- as.matrix(Y)
+        Y <- scale(Y, center = TRUE, scale = FALSE)
+        SS.Y <- sum(Y * Y)
+    }
     X1 <- as.matrix(X1)
     X2 <- as.matrix(X2)
     n <- nrow(Y)
@@ -14,10 +23,8 @@
         stop("Y and X1 do not have the same number of rows")
     if (n2 != n) 
         stop("Y and X2 do not have the same number of rows")
-    Y <- scale(Y, center = TRUE, scale = FALSE)
     X1 <- scale(X1, center = TRUE, scale = FALSE)
     X2 <- scale(X2, center = TRUE, scale = FALSE)
-    SS.Y <- sum(Y * Y)
     dummy <- simpleRDA2(Y, X1, SS.Y, mm1)
     ab.ua <- dummy$Rsquare
     m1 <- dummy$m

--- a/R/varpart3.R
+++ b/R/varpart3.R
@@ -1,7 +1,16 @@
-"varpart3" <-
+`varpart3` <-
     function (Y, X1, X2, X3) 
 {
-    Y <- as.matrix(Y)
+    if (inherits(Y, "dist")) {
+        Y <- GowerDblcen(as.matrix(Y^2), na.rm = FALSE)
+        Y <- -Y/2
+        SS.Y <- sum(diag(Y))
+        simpleRDA2 <- match.fun(simpleDBRDA)
+    } else {
+        Y <- as.matrix(Y)
+        Y <- scale(Y, center = TRUE, scale = FALSE)
+        SS.Y <- sum(Y * Y)
+    }
     X1 <- as.matrix(X1)
     X2 <- as.matrix(X2)
     X3 <- as.matrix(X3)
@@ -19,11 +28,9 @@
         stop("Y and X2 do not have the same number of rows")
     if (n3 != n) 
         stop("Y and X3 do not have the same number of rows")
-    Y <- scale(Y, center = TRUE, scale = FALSE)
     X1 <- scale(X1, center = TRUE, scale = FALSE)
     X2 <- scale(X2, center = TRUE, scale = FALSE)
     X3 <- scale(X3, center = TRUE, scale = FALSE)
-    SS.Y <- sum(Y * Y)
     dummy <- simpleRDA2(Y, X1, SS.Y, mm1)
     adfg.ua <- dummy$Rsquare
     m1 <- dummy$m

--- a/R/varpart4.R
+++ b/R/varpart4.R
@@ -1,7 +1,16 @@
-"varpart4" <-
+`varpart4` <-
     function (Y, X1, X2, X3, X4) 
 {
-    Y <- as.matrix(Y)
+    if (inherits(Y, "dist")) {
+        Y <- GowerDblcen(as.matrix(Y^2), na.rm = FALSE)
+        Y <- -Y/2
+        SS.Y <- sum(diag(Y))
+        simpleRDA2 <- match.fun(simpleDBRDA)
+    } else {
+        Y <- as.matrix(Y)
+        Y <- scale(Y, center = TRUE, scale = FALSE)
+        SS.Y <- sum(Y * Y)
+    }
     X1 <- as.matrix(X1)
     X2 <- as.matrix(X2)
     X3 <- as.matrix(X3)
@@ -24,12 +33,10 @@
         stop("Y and X3 do not have the same number of rows")
     if (n4 != n) 
         stop("Y and X4 do not have the same number of rows")
-    Y <- scale(Y, center = TRUE, scale = FALSE)
     X1 <- scale(X1, center = TRUE, scale = FALSE)
     X2 <- scale(X2, center = TRUE, scale = FALSE)
     X3 <- scale(X3, center = TRUE, scale = FALSE)
     X4 <- scale(X4, center = TRUE, scale = FALSE)
-    SS.Y <- sum(Y * Y)
     dummy <- simpleRDA2(Y, X1, SS.Y)
     aeghklno.ua <- dummy$Rsquare
     m1 <- dummy$m

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -7,6 +7,7 @@
 \alias{plot.varpart}
 \alias{plot.varpart234}
 \alias{simpleRDA2}
+\alias{simpleDBRDA}
 
 \title{Partition the Variation of Community Matrix by 2, 3, or 4 Explanatory Matrices }
 
@@ -97,12 +98,13 @@ showvarparts(parts, labels, bg = NULL, alpha = 63, Xnames,
   partitioning is based on linear regression.  If \code{Y} are
   dissimilarities, the decomposition is based on distance-based
   redundancy analysis (db-RDA, see \code{\link{capscale}}) following
-  McArdle & Anderson (2001). The input dissimilarities must inherit
-  from \code{"dist"} class. Function \code{\link{dist}},
-  \code{\link{vegdist}} and \code{\link{designdist}} produce such
+  McArdle & Anderson (2001). The input dissimilarities must be
+  compatible to the results of \code{\link{dist}}. \pkg{Vegan}
+  functions \code{\link{vegdist}}, \code{\link{designdist}},
+  \code{\link{raupcrick}} and \code{\link{betadiver}} produce such
   objects, as do many other dissimilarity functions in \R
-  packages. However, symmetric square matrices must be transformed
-  with \code{\link{as.dist}}.
+  packages. However, symmetric square matrices are not recognized as
+  dissimilarities but must be transformed with \code{\link{as.dist}}.
 
   The function primarily uses adjusted \eqn{R^2}{R-squared} to assess
   the partitions explained by the explanatory tables and their
@@ -244,22 +246,23 @@ Montreal, Canada.  Further developed by Jari Oksanen. }
 
   The functions frequently give negative estimates of variation.
   Adjusted \eqn{R^2}{R-squared} can be negative for any fraction;
-  unadjusted \eqn{R^2}{R-squared} of testable fractions always will be
-  non-negative.  Non-testable fractions cannot be found directly, but
-  by subtracting different models, and these subtraction results can
-  be negative.  The fractions are orthogonal, or linearly independent,
-  but more complicated or nonlinear dependencies can cause negative
-  non-testable fractions.
+  unadjusted \eqn{R^2}{R-squared} of testable fractions of variances
+  will be non-negative.  Non-testable fractions cannot be found
+  directly, but by subtracting different models, and these subtraction
+  results can be negative.  The fractions are orthogonal, or linearly
+  independent, but more complicated or nonlinear dependencies can
+  cause negative non-testable fractions. Any fraction can be negative
+  for non-Euclidean dissimilarities.
 
   The current function will only use RDA in multivariate
   partitioning. It is much more complicated to estimate the adjusted
   R-squares for CCA, and unbiased analysis of CCA is not currently
   implemented.
 
-  A simplified, fast version of RDA is used (function
-  \code{simpleRDA2}).  The actual calculations are done in functions
-  \code{varpart2} to \code{varpart4}, but these are not intended to be
-  called directly by the user.
+  A simplified, fast version of RDA or dbRDA are used (functions
+  \code{simpleRDA2} and \code{simpleDBRDA}).  The actual calculations
+  are done in functions \code{varpart2} to \code{varpart4}, but these
+  are not intended to be called directly by the user.
 
 }
 
@@ -302,6 +305,8 @@ anova(aFrac, step=200, perm.max=200)
 # RsquareAdj gives the same result as component [a] of varpart
 RsquareAdj(aFrac)
 
+# Partition Bray-Curtis dissimilarities
+varpart(vegdist(mite), ~ ., mite.pcnm, data = mite.env)
 # Three explanatory matrices 
 mod <- varpart(mite, ~ SubsDens + WatrCont, ~ Substrate + Shrub + Topo,
    mite.pcnm, data=mite.env, transfo="hel")

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -11,12 +11,15 @@
 \title{Partition the Variation of Community Matrix by 2, 3, or 4 Explanatory Matrices }
 
 \description{ 
-  The function partitions the variation of response table Y with
-  respect to two, three, or four explanatory tables, using adjusted
-  \eqn{R^2}{R-squared} in redundancy analysis ordination (RDA). If Y
-  contains a single vector, partitioning is by partial regression.
-  Collinear variables in the explanatory tables do NOT have to be
-  removed prior to partitioning.  
+
+  The function partitions the variation in community data or community
+  dissimilarities with respect to two, three, or four explanatory
+  tables, using adjusted \eqn{R^2}{R-squared} in redundancy analysis
+  ordination (RDA) or distance-based redundancy analysis. If response
+  is a single vector, partitioning is by partial regression. Collinear
+  variables in the explanatory tables do NOT have to be removed prior
+  to partitioning.
+
 }
 
 \usage{
@@ -27,9 +30,12 @@ showvarparts(parts, labels, bg = NULL, alpha = 63, Xnames,
 }
 
 \arguments{
-\item{Y}{ Data frame or matrix containing the response data
-table. In community ecology, that table is often a site-by-species
-table. }
+
+\item{Y}{ Data frame or matrix containing the response data table or
+  dissimilarity structure inheriting from \code{\link{dist}}. In
+  community ecology, that table is often a site-by-species table or a
+  dissimilarity object. }
+
 \item{X}{Two to four explanatory models, variables or tables.  These can
   be defined in three alternative ways: (1) one-sided model formulae
   beginning with \code{~} and then defining the model, (2) name of a
@@ -46,11 +52,16 @@ table. }
   }
 \item{data}{The data frame with the variables used in the formulae in
   \code{X}.} 
+
 \item{transfo}{ Transformation for \code{Y} (community data) using
-  \code{\link{decostand}}.  All alternatives in \code{decostand} can be
-    used, and those preserving Euclidean metric include
-    \code{"hellinger"}, \code{"chi.square"}, \code{"total"}, \code{"norm"}.}
-\item{scale}{Should the columns of \code{Y} be standardized to unit variance}
+  \code{\link{decostand}}.  All alternatives in \code{decostand} can
+  be used, and those preserving Euclidean metric include
+  \code{"hellinger"}, \code{"chi.square"}, \code{"total"},
+  \code{"norm"}. Ignored if \code{Y} are dissimilarities.}
+
+\item{scale}{Should the columns of \code{Y} be standardized to unit
+  variance. Ignored if \code{Y} are dissimilarities.}
+
 \item{parts}{Number of explanatory tables (circles) displayed.}
 \item{labels}{Labels used for displayed fractions. Default is to use
   the same letters as in the printed output.}
@@ -77,12 +88,21 @@ table. }
 }
 
 \details{
+
   The functions partition the variation in \code{Y} into components
   accounted for by two to four explanatory tables and their combined
-  effects. If \code{Y} is a multicolumn data frame or
-  matrix, the partitioning is based on redundancy analysis (RDA, see
+  effects. If \code{Y} is a multicolumn data frame or matrix, the
+  partitioning is based on redundancy analysis (RDA, see
   \code{\link{rda}}), and if \code{Y} is a single variable, the
-  partitioning is based on linear regression.  
+  partitioning is based on linear regression.  If \code{Y} are
+  dissimilarities, the decomposition is based on distance-based
+  redundancy analysis (db-RDA, see \code{\link{capscale}}) following
+  McArdle & Anderson (2001). The input dissimilarities must inherit
+  from \code{"dist"} class. Function \code{\link{dist}},
+  \code{\link{vegdist}} and \code{\link{designdist}} produce such
+  objects, as do many other dissimilarity functions in \R
+  packages. However, symmetric square matrices must be transformed
+  with \code{\link{as.dist}}.
 
   The function primarily uses adjusted \eqn{R^2}{R-squared} to assess
   the partitions explained by the explanatory tables and their
@@ -97,14 +117,14 @@ table. }
   or can be displayed graphically using function
   \code{showvarparts}.
 
-  A fraction is testable if it can be directly
-  expressed as an RDA model.  In these cases the printed output also
-  displays the corresponding RDA model using notation where explanatory
-  tables after \code{|} are conditions (partialled out; see
-  \code{\link{rda}} for details). Although single fractions can be
-  testable, this does not mean that all fractions simultaneously can be
-  tested, since there number of  testable fractions  is higher than
-  the number of estimated models.
+  A fraction is testable if it can be directly expressed as an RDA or
+  db-RDA model.  In these cases the printed output also displays the
+  corresponding RDA model using notation where explanatory tables
+  after \code{|} are conditions (partialled out; see \code{\link{rda}}
+  for details). Although single fractions can be testable, this does
+  not mean that all fractions simultaneously can be tested, since
+  there number of testable fractions is higher than the number of
+  estimated models.
 
   An abridged explanation of the alphabetic symbols for the individual
   fractions follows, but computational details should be checked in
@@ -202,10 +222,17 @@ transformations for ordination of species data. Oecologia 129: 271--280.
 Peres-Neto, P., P. Legendre, S. Dray and D. Borcard. 2006. Variation partitioning
 of species data matrices: estimation and comparison of fractions.
 Ecology 87: 2614--2625.
- }
+
+(d) References on partitioning of dissimilarities
+
+McArdle, B.H. & Anderson, M.J. (2001). Fitting multivariate models
+to community data: a comment on distance-based redundancy
+analysis. Ecology 82, 290-297.
+
+}
 
 \author{ Pierre Legendre, Departement de Sciences Biologiques, Universite de
-Montreal, Canada.  Adapted to \pkg{vegan} by Jari Oksanen. }
+Montreal, Canada.  Further developed by Jari Oksanen. }
 
 \note{
 

--- a/man/vegan-internal.Rd
+++ b/man/vegan-internal.Rd
@@ -12,6 +12,7 @@
 \alias{veganCovEllipse}
 \alias{hierParseFormula}
 \alias{veganMahatrans}
+\alias{GowerDblcen}
 
 \title{Internal vegan functions}
 
@@ -35,6 +36,7 @@ pasteCall(call, prefix = "Call:")
 veganCovEllipse(cov, center = c(0, 0), scale = 1, npoints = 100)
 veganMahatrans(x, s2, tol = 1e-8)
 hierParseFormula(formula, data)
+GowerDblcen(x, na.rm = TRUE)
 }
 
 \details{ The description here is only intended for \pkg{vegan}
@@ -97,6 +99,11 @@ hierParseFormula(formula, data)
   and a model frame with factors representing hierarchy levels 
   (right hand side) to be used in \code{\link{adipart}}, 
   \code{\link{multipart}} and \code{\link{hiersimu}}.
+
+  \code{GowerDblcen} performs the Gower double centring of a matrix of
+  dissimilarities. Similar function was earlier available as a compiled
+  code in \pkg{stats}, but it is not a part of official API, and
+  therefore we have this poorer replacement.
 }
 
 \keyword{internal }


### PR DESCRIPTION
Partition dissimilarities in `varpart` as an alternative to raw data. The PR is analogous to PR #126 and applies similar methodology for partitioning of variance. However, there is no overlap of code, but this PR can be applied independently of PR #126. 

Distance partitioning needed only small changes in code. I added internal  `simpleDBRDA` function which is analogous to the old `simpleRDA2`, lifted `dblcen` from `betadisper` to an independent internal function `GowerDblcen`, and edited `varpart`and `varpart234` functions to use these if users supply `"dist"` objects instead of rectangular data. 

This needs @legendre's approval.