### PR TITLE
New adonis

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -38,6 +38,8 @@ export(anova.cca)
 export(as.mcmc.oecosimu, as.mcmc.permat)
 ## export oldCapscale for compatibility after new capscale design
 export(oldCapscale)
+## alternative implementation of adonis: may be eliminated later
+export(adonis2)
 
 ## export regular functions with dot names
 

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -1,6 +1,6 @@
 `adonis2` <-
-    function(formula, data, method = "bray", by = "term",
-             permutations = 999, parallel = getOption("mc.cores"), ...)
+    function(formula, data, permutations = 999, method = "bray",
+             by = "term", parallel = getOption("mc.cores"), ...)
 {
     environment(formula) <- environment()
     sol <- adonis0(formula, data = data, method = "bray")

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -4,8 +4,13 @@
 {
     environment(formula) <- environment()
     sol <- adonis0(formula, data = data, method = "bray")
-    anova(sol, permutations = permutations, by = by,
-          parallel = parallel)
+    out <- anova(sol, permutations = permutations, by = by,
+                 parallel = parallel)
+    ## Fix method name in output
+    head <- attr(out, "heading")
+    head[2] <- sub("adonis0", "adonis2", head[2])
+    attr(out, "heading") <- head
+    out
 }
 `adonis0` <-
     function(formula, data=NULL, method="bray", ...)

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -25,8 +25,11 @@
     op.c <- options()$contrasts
     options( contrasts=c(contr.unordered, contr.ordered) )
     rhs <- model.matrix(formula, rhs.frame) # and finally the model.matrix
-    options(contrasts=op.c)
     grps <- attr(rhs, "assign")
+    rhs <- rhs[,-1, drop=FALSE] # remove the (Intercept) to get rank right
+    grps <- grps[-1]
+    rhs <- scale(rhs, scale = FALSE, center = TRUE) # center
+    options(contrasts=op.c)
     qrhs <- qr(rhs)
     ## Take care of aliased variables and pivoting in rhs
     rhs <- rhs[, qrhs$pivot, drop=FALSE]

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -1,6 +1,11 @@
 `adonis2` <-
     function(formula, data=NULL, method="bray", ...)
 {
+    ## evaluate data
+    if (missing(data))
+        data <- .GlobalEnv
+    else
+        data <- ordiGetData(match.call(), environment(formula))
     ## First we collect info for the uppermost level of the analysed
     ## object
     Trms <- terms(delete.response(formula), data = data)

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -33,12 +33,10 @@
     qrhs <- qr(rhs)
     ## Take care of aliased variables and pivoting in rhs
     rhs <- rhs[, qrhs$pivot, drop=FALSE]
-    rhs <- rhs[, 1:qrhs$rank, drop=FALSE]
+    rhs <- rhs[, seq_len(qrhs$rank), drop=FALSE]
     grps <- grps[qrhs$pivot][1:qrhs$rank]
     u.grps <- unique(grps)
-    nterms <- length(u.grps) - 1
-    if (nterms < 1)
-        stop("right-hand-side of formula has no usable terms")
+    nterms <- length(u.grps)
     ## handle dissimilarities
     if (inherits(lhs, "dist")) {
         if (any(lhs < -TOL))
@@ -56,13 +54,16 @@
     Gfit <- qr.fitted(qrhs, G)
     Gres <- qr.resid(qrhs, G)
     ## collect data for the fit
-    CCA <- list(rank = qrhs$rank,
-                qrank = qrhs$rank,
-                tot.chi = sum(diag(Gfit)),
-                QR = qrhs,
-                G = G)
+    if(nterms) 
+        CCA <- list(rank = qrhs$rank,
+                    qrank = qrhs$rank,
+                    tot.chi = sum(diag(Gfit)),
+                    QR = qrhs,
+                    G = G)
+    else
+        CCA <- NULL # empty model
     ## collect data for the residuals
-    CA <- list(rank = n - qrhs$rank - 1,
+    CA <- list(rank = n - max(qrhs$rank, 0) - 1,
                u = matrix(0, nrow=n),
                tot.chi = sum(diag(Gres)),
                Xbar = Gres)
@@ -70,6 +71,6 @@
     sol$tot.chi <- sum(diag(G))
     sol$CCA <- CCA
     sol$CA <- CA
-    class(sol) <- c("adonis", "capscale", "rda", "cca")
+    class(sol) <- c("adonis2", "capscale", "rda", "cca")
     sol
 }

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -1,7 +1,7 @@
 `adonis2` <-
-    function(formula, data=NULL, permutations=999, method="bray", strata=NULL,
+    function(formula, data=NULL, method="bray",
              contr.unordered="contr.sum", contr.ordered="contr.poly",
-             parallel = getOption("mc.cores"), ...)
+             ...)
 {
     ## First we collect info for the uppermost level of the analysed
     ## object

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -20,28 +20,18 @@
     Trms <- terms(delete.response(formula), data = data)
     sol <- list(call = match.call(),
                 method = "adonis",
-                formula = formula(Trms),
                 terms = Trms,
                 terminfo = list(terms = Trms))
     sol$call$formula <- formula(Trms)
-    ## formula is model formula such as Y ~ A + B*C where Y is a data
-    ## frame or a matrix, and A, B, and C may be factors or continuous
-    ## variables.  data is the data frame from which A, B, and C would
-    ## be drawn.
     TOL <- 1e-7
     Terms <- terms(formula, data = data)
     lhs <- formula[[2]]
     lhs <- eval(lhs, data, parent.frame()) # to force evaluation
     formula[[2]] <- NULL                # to remove the lhs
     rhs.frame <- model.frame(formula, data, drop.unused.levels = TRUE) # to get the data frame of rhs
-    ##op.c <- options()$contrasts
-    ##options( contrasts=c(contr.unordered, contr.ordered) )
     rhs <- model.matrix(formula, rhs.frame) # and finally the model.matrix
-    ##grps <- attr(rhs, "assign")
     rhs <- rhs[,-1, drop=FALSE] # remove the (Intercept) to get rank right
-    ##grps <- grps[-1]
     rhs <- scale(rhs, scale = FALSE, center = TRUE) # center
-    ##options(contrasts=op.c)
     qrhs <- qr(rhs)
     ## handle dissimilarities
     if (inherits(lhs, "dist")) {

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -1,0 +1,160 @@
+`adonis` <-
+    function(formula, data=NULL, permutations=999, method="bray", strata=NULL,
+             contr.unordered="contr.sum", contr.ordered="contr.poly",
+             parallel = getOption("mc.cores"), ...)
+{
+    ## formula is model formula such as Y ~ A + B*C where Y is a data
+    ## frame or a matrix, and A, B, and C may be factors or continuous
+    ## variables.  data is the data frame from which A, B, and C would
+    ## be drawn.
+    TOL <- 1e-7
+    Terms <- terms(formula, data = data)
+    lhs <- formula[[2]]
+    lhs <- eval(lhs, data, parent.frame()) # to force evaluation
+    formula[[2]] <- NULL                # to remove the lhs
+    rhs.frame <- model.frame(formula, data, drop.unused.levels = TRUE) # to get the data frame of rhs
+    op.c <- options()$contrasts
+    options( contrasts=c(contr.unordered, contr.ordered) )
+    rhs <- model.matrix(formula, rhs.frame) # and finally the model.matrix
+    options(contrasts=op.c)
+    grps <- attr(rhs, "assign")
+    qrhs <- qr(rhs)
+    ## Take care of aliased variables and pivoting in rhs
+    rhs <- rhs[, qrhs$pivot, drop=FALSE]
+    rhs <- rhs[, 1:qrhs$rank, drop=FALSE]
+    grps <- grps[qrhs$pivot][1:qrhs$rank]
+    u.grps <- unique(grps)
+    nterms <- length(u.grps) - 1
+    if (nterms < 1)
+        stop("right-hand-side of formula has no usable terms")
+    H.s <- lapply(2:length(u.grps),
+                  function(j) {Xj <- rhs[, grps %in% u.grps[1:j] ]
+                               qrX <- qr(Xj, tol=TOL)
+                               Q <- qr.Q(qrX)
+                               tcrossprod(Q[,1:qrX$rank])
+                           })
+    if (inherits(lhs, "dist")) {
+        if (any(lhs < -TOL))
+            stop("dissimilarities must be non-negative")
+        dmat <- as.matrix(lhs^2)
+    }
+    else {
+        dist.lhs <- as.matrix(vegdist(lhs, method=method, ...))
+        dmat <- dist.lhs^2
+    }
+    n <- nrow(dmat)
+    ## G is -dmat/2 centred by rows
+    G <- -sweep(dmat, 1, rowMeans(dmat))/2
+    SS.Exp.comb <- sapply(H.s, function(hat) sum( G * t(hat)) )
+    SS.Exp.each <- c(SS.Exp.comb - c(0,SS.Exp.comb[-nterms]) )
+    H.snterm <- H.s[[nterms]]
+    ## t(I - H.snterm) is needed several times and we calculate it
+    ## here
+    tIH.snterm <- t(diag(n)-H.snterm)
+    if (length(H.s) > 1)
+        for (i in length(H.s):2)
+            H.s[[i]] <- H.s[[i]] - H.s[[i-1]]
+    SS.Res <- sum( G * tIH.snterm)
+    df.Exp <- sapply(u.grps[-1], function(i) sum(grps==i) )
+    df.Res <- n - qrhs$rank
+    ## Get coefficients both for the species (if possible) and sites
+    if (inherits(lhs, "dist")) {
+        beta.sites <- qr.coef(qrhs, as.matrix(lhs))
+        beta.spp <-  NULL
+    } else {
+        beta.sites <- qr.coef(qrhs, dist.lhs)
+        beta.spp <-  qr.coef(qrhs, as.matrix(lhs))
+    }
+    colnames(beta.spp) <- colnames(lhs)
+    colnames(beta.sites) <- rownames(lhs)
+    F.Mod <- (SS.Exp.each/df.Exp) / (SS.Res/df.Res)
+
+    f.test <- function(tH, G, df.Exp, df.Res, tIH.snterm) {
+      ## HERE I TRY CHANGING t(H)  TO tH, and
+      ## t(I - H.snterm) to tIH.snterm, so that we don't have
+      ## to do those calculations for EACH iteration.
+      ## This is the function we have to do for EACH permutation.
+      ## G is an n x n centered distance matrix
+      ## H is the hat matrix from the design (X)
+      ## note that for R, * is element-wise multiplication,
+      ## whereas %*% is matrix multiplication.
+        (sum(G * tH)/df.Exp) /
+          (sum(G * tIH.snterm)/df.Res) }
+
+ ### Old f.test
+    ### f.test <- function(H, G, I, df.Exp, df.Res, H.snterm){
+    ##    (sum( G * t(H) )/df.Exp) /
+      ##    (sum( G * t(I-H.snterm) )/df.Res) }
+
+    SS.perms <- function(H, G, I){
+        c(SS.Exp.p = sum( G * t(H) ),
+          S.Res.p=sum( G * t(I-H) )
+          ) }
+
+    ## Permutations
+    p <- getPermuteMatrix(permutations, n, strata = strata)
+    permutations <- nrow(p)
+    if (permutations) {
+        tH.s <- lapply(H.s, t)
+        ## Apply permutations for each term
+        ## This is the new f.test (2011-06-15) that uses fewer arguments
+        ## Set first parallel processing for all terms
+        if (is.null(parallel))
+            parallel <- 1
+        hasClus <- inherits(parallel, "cluster")
+        isParal <- hasClus || parallel > 1
+        isMulticore <- .Platform$OS.type == "unix" && !hasClus
+        if (isParal && !isMulticore && !hasClus) {
+            parallel <- makeCluster(parallel)
+        }
+        if (isParal) {
+            if (isMulticore) {
+                f.perms <-
+                    sapply(1:nterms, function(i)
+                           unlist(mclapply(1:permutations, function(j)
+                                           f.test(tH.s[[i]], G[p[j,], p[j,]],
+                                                  df.Exp[i], df.Res, tIH.snterm),
+                                           mc.cores = parallel)))
+            } else {
+                f.perms <-
+                    sapply(1:nterms, function(i)
+                           parSapply(parallel, 1:permutations, function(j)
+                                     f.test(tH.s[[i]], G[p[j,], p[j,]],
+                                            df.Exp[i], df.Res, tIH.snterm)))
+            }
+        } else {
+            f.perms <-
+                sapply(1:nterms, function(i) 
+                       sapply(1:permutations, function(j) 
+                              f.test(tH.s[[i]], G[p[j,], p[j,]],
+                                     df.Exp[i], df.Res, tIH.snterm)))
+        }
+        ## Close socket cluster if created here
+        if (isParal && !isMulticore && !hasClus)
+            stopCluster(parallel)
+        ## Round to avoid arbitrary P-values with tied data
+        f.perms <- round(f.perms, 12)
+        F.Mod <- round(F.Mod, 12)
+        P <- (rowSums(t(f.perms) >= F.Mod)+1)/(permutations+1)
+    } else { # no permutations
+        f.perms <- P <- rep(NA, nterms)
+    }
+    SumsOfSqs = c(SS.Exp.each, SS.Res, sum(SS.Exp.each) + SS.Res)
+    tab <- data.frame(Df = c(df.Exp, df.Res, n-1),
+                      SumsOfSqs = SumsOfSqs,
+                      MeanSqs = c(SS.Exp.each/df.Exp, SS.Res/df.Res, NA),
+                      F.Model = c(F.Mod, NA,NA),
+                      R2 = SumsOfSqs/SumsOfSqs[length(SumsOfSqs)],
+                      P = c(P, NA, NA))
+    rownames(tab) <- c(attr(attr(rhs.frame, "terms"), "term.labels")[u.grps],
+                       "Residuals", "Total")
+    colnames(tab)[ncol(tab)] <- "Pr(>F)"
+    attr(tab, "heading") <- c(howHead(attr(p, "control")),
+        "Terms added sequentially (first to last)\n")
+    class(tab) <- c("anova", class(tab))
+    out <- list(aov.tab = tab, call = match.call(),
+                coefficients = beta.spp, coef.sites = beta.sites,
+                f.perms = f.perms, model.matrix = rhs, terms = Terms)
+    class(out) <- "adonis"
+    out
+}

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -1,4 +1,13 @@
 `adonis2` <-
+    function(formula, data, method = "bray", by = "term",
+             permutations = 999, parallel = getOption("mc.cores"), ...)
+{
+    environment(formula) <- environment()
+    sol <- adonis0(formula, data = data, method = "bray")
+    anova(sol, permutations = permutations, by = by,
+          parallel = parallel)
+}
+`adonis0` <-
     function(formula, data=NULL, method="bray", ...)
 {
     ## evaluate data

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -1,7 +1,5 @@
 `adonis2` <-
-    function(formula, data=NULL, method="bray",
-             contr.unordered="contr.sum", contr.ordered="contr.poly",
-             ...)
+    function(formula, data=NULL, method="bray", ...)
 {
     ## First we collect info for the uppermost level of the analysed
     ## object
@@ -22,14 +20,14 @@
     lhs <- eval(lhs, data, parent.frame()) # to force evaluation
     formula[[2]] <- NULL                # to remove the lhs
     rhs.frame <- model.frame(formula, data, drop.unused.levels = TRUE) # to get the data frame of rhs
-    op.c <- options()$contrasts
-    options( contrasts=c(contr.unordered, contr.ordered) )
+    ##op.c <- options()$contrasts
+    ##options( contrasts=c(contr.unordered, contr.ordered) )
     rhs <- model.matrix(formula, rhs.frame) # and finally the model.matrix
-    grps <- attr(rhs, "assign")
+    ##grps <- attr(rhs, "assign")
     rhs <- rhs[,-1, drop=FALSE] # remove the (Intercept) to get rank right
-    grps <- grps[-1]
+    ##grps <- grps[-1]
     rhs <- scale(rhs, scale = FALSE, center = TRUE) # center
-    options(contrasts=op.c)
+    ##options(contrasts=op.c)
     qrhs <- qr(rhs)
     ## handle dissimilarities
     if (inherits(lhs, "dist")) {

--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -31,12 +31,6 @@
     rhs <- scale(rhs, scale = FALSE, center = TRUE) # center
     options(contrasts=op.c)
     qrhs <- qr(rhs)
-    ## Take care of aliased variables and pivoting in rhs
-    rhs <- rhs[, qrhs$pivot, drop=FALSE]
-    rhs <- rhs[, seq_len(qrhs$rank), drop=FALSE]
-    grps <- grps[qrhs$pivot][1:qrhs$rank]
-    u.grps <- unique(grps)
-    nterms <- length(u.grps)
     ## handle dissimilarities
     if (inherits(lhs, "dist")) {
         if (any(lhs < -TOL))
@@ -54,7 +48,7 @@
     Gfit <- qr.fitted(qrhs, G)
     Gres <- qr.resid(qrhs, G)
     ## collect data for the fit
-    if(nterms) 
+    if(!is.null(qrhs$rank) && qrhs$rank > 0) 
         CCA <- list(rank = qrhs$rank,
                     qrank = qrhs$rank,
                     tot.chi = sum(diag(Gfit)),

--- a/R/anova.cca.R
+++ b/R/anova.cca.R
@@ -61,9 +61,14 @@
     Pval <- (sum(tst$F.perm >= tst$F.0) + 1)/(tst$nperm + 1)
     Pval <- c(Pval, NA)
     table <- data.frame(tst$df, tst$chi, Fval, Pval)
-    is.rda <- inherits(object, "rda")
-    colnames(table) <- c("Df", ifelse(is.rda, "Variance", "ChiSquare"),
-                         "F", "Pr(>F)")
+    if (inherits(object, "capscale") &&
+        (object$adjust != 1 || is.null(object$adjust)))
+        varname <- "SumOfSqs"
+    else if (inherits(object, "rda"))
+        varname <- "Variance"
+    else
+        varname <- "ChiSquare"
+    colnames(table) <- c("Df", varname, "F", "Pr(>F)")
     head <- paste0("Permutation test for ", tst$method, " under ",
                   tst$model, " model\n", howHead(control))
     mod <- paste("Model:", c(object$call))

--- a/R/anova.ccabyterm.R
+++ b/R/anova.ccabyterm.R
@@ -34,9 +34,14 @@
                       c(sol[-1, 4], sol[ntrm+1, 2]),
                       c(sol[-1, 5], NA),
                       c(sol[-1, 6], NA))
-    isRDA <- inherits(object, "rda")
-    colnames(out) <- c("Df", ifelse(isRDA, "Variance", "ChiSquare"),
-                       "F", "Pr(>F)")
+    if (inherits(object, "capscale") &&
+        (object$adjust != 1 || is.null(object$adjust)))
+        varname <- "SumOfSqs"
+    else if (inherits(object, "rda"))
+        varname <- "Variance"
+    else
+        varname <- "ChiSquare"
+    colnames(out) <- c("Df", varname, "F", "Pr(>F)")
     rownames(out) <- c(trmlab, "Residual")
     head <- paste0("Permutation test for ", object$method, " under ",
                    model, " model\n",
@@ -101,9 +106,14 @@
     ## Collect results to anova data.frame
     out <- data.frame(c(Df, dfbig), c(Chisq, chibig),
                       c(Fstat, NA), c(Pval, NA))
-    isRDA <- inherits(object, "rda")
-    colnames(out) <- c("Df", ifelse(isRDA, "Variance", "ChiSquare"),
-                       "F", "Pr(>F)")
+    if (inherits(object, "capscale") &&
+        (object$adjust != 1 || is.null(object$adjust)))
+        varname <- "SumOfSqs"
+    else if (inherits(object, "rda"))
+        varname <- "Variance"
+    else
+        varname <- "ChiSquare"
+    colnames(out) <- c("Df", varname, "F", "Pr(>F)")
     rownames(out) <- c(trmlab, "Residual")
     head <- paste0("Permutation test for ", object$method, " under ",
                    mods[[1]]$model, " model\n",

--- a/R/ordiGetData.R
+++ b/R/ordiGetData.R
@@ -1,7 +1,7 @@
 `ordiGetData` <-
 function (call, env) 
 {
-    call$scale <- call$distance <- call$comm <- call$add <-
+    call$scale <- call$distance <- call$comm <- call$add <- call$method <- 
         call$dfun <- call$sqrt.dist <- call$metaMDSdist <- call$subset <- NULL
     call$na.action <- na.pass
     call[[2]] <- NULL

--- a/man/adonis.Rd
+++ b/man/adonis.Rd
@@ -1,6 +1,7 @@
 \encoding{UTF-8}
 \name{adonis}
 \alias{adonis}
+\alias{adonis2}
 
 \title{Permutational Multivariate Analysis of Variance Using Distance Matrices}
 

--- a/man/adonis.Rd
+++ b/man/adonis.Rd
@@ -12,8 +12,10 @@
 
 \usage{
 adonis(formula, data, permutations = 999, method = "bray",
-       strata = NULL, contr.unordered = "contr.sum",
-       contr.ordered = "contr.poly", parallel = getOption("mc.cores"), ...)
+    strata = NULL, contr.unordered = "contr.sum",
+    contr.ordered = "contr.poly", parallel = getOption("mc.cores"), ...)
+adonis2(formula, data, permutations = 999, method = "bray", by = "term",
+    parallel = getOption("mc.cores"), ...)
 }
 
 \arguments{  
@@ -31,7 +33,13 @@ adonis(formula, data, permutations = 999, method = "bray",
     row gives the permuted indices.}
   \item{method}{ the name of any method used in \code{\link{vegdist}} to
     calculate pairwise distances if the left hand side of the
-    \code{formula} was a data frame or a matrix. } 
+    \code{formula} was a data frame or a matrix. }
+  \item{by}{\code{by = "terms"} will assess significance for each term
+    (sequentially from first to last), setting \code{by = "margin"}
+    will assess the marginal effects of the terms (each marginal term
+    analysed in a model with all other variables), and \code{by =
+    NULL} will assess the overall significance of all terms
+    together. The arguments is passed on to \code{\link{anova.cca}}.}
   \item{strata}{ groups (strata) within which to constrain permutations.  }
   \item{contr.unordered, contr.ordered}{contrasts used for the design
     matrix (default in R is dummy or treatment contrasts for unordered
@@ -47,14 +55,26 @@ adonis(formula, data, permutations = 999, method = "bray",
 sums of squares using semimetric and metric distance matrices. Insofar
 as it partitions sums of squares of a multivariate data set, it is
 directly analogous to MANOVA (multivariate analysis of
-variance). M.J. Anderson (McArdle and Anderson 2001, Anderson 2001) refers to the
-method as \dQuote{permutational manova} (formerly \dQuote{nonparametric manova}). Further, as its inputs are
-linear predictors, and a response matrix of an arbitrary number of
-columns (2 to millions), it is a robust alternative to both parametric
-MANOVA and to ordination methods for describing how variation is
-attributed to different experimental treatments or uncontrolled
-covariates. It is also analogous to redundancy analysis (Legendre and
+variance). McArdle and Anderson (2001) and Anderson (2001)
+refer to the method as \dQuote{permutational manova} (formerly
+\dQuote{nonparametric manova}). Further, as its inputs are linear
+predictors, and a response matrix of an arbitrary number of columns (2
+to millions), it is a robust alternative to both parametric MANOVA and
+to ordination methods for describing how variation is attributed to
+different experimental treatments or uncontrolled covariates. It is
+also analogous to distance-based redundancy analysis (Legendre and
 Anderson 1999).
+
+Function \code{adonis} is directly based on the algorithm of Anderson
+(2001) and performs a sequential test of terms. Function
+\code{adonis2} is based on the principles of McArdle & Anderson (2001)
+and can perform sequential, marginal and overall tests. Function
+\code{adonis2} can be much slower than \code{adonis}, in particular
+with several terms. With the same random permutation, sequential tests
+are identical in both functions, and the results are also identical to
+\code{\link{anova.cca}} of \code{\link{capscale}}. With Euclidean
+distances, the sequential tests are also identical to
+\code{\link{anova.cca}} of \code{\link{rda}}.
 
 Typical uses of \code{adonis} include analysis of ecological community
 data (samples X species matrices) or genetic data where we might have a


### PR DESCRIPTION
This is a new alternative implementation of `adonis` based on `anova.cca`. The main advantage is that this PR will provide marginal and overall tests in addition to the sequential tests of old `adonis`. The main disadvantage is that this runs much more slowly. Therefore I provide the new test as an alternative function `adonis2`  and keep the old `adonis`.

The new `adonis2`  is the public and exported function. Basically, it contains little more than an internal function `adonis0`  that creates a minimal `"capscale"` like object and `anova`  call that runs the test with that minimal `"capscale"` object. The `adonis0`  result contains only items that are necessary to run sequential or marginal `anova`, but it skips all eigenanalysis and is therefore faster than full-blown `capscale`. However, since `adonis0` or `capscale` are run only once per permutation cycle, the time saving is rather small (about 5% in my tests), and most time is spent in `anova.cca`. It seems that the sequential tests in old `adonis`  are very efficient. In `anova.cca`  we need to run separate permutations for each term and this is much slower. However, `anova.cca` benefits much from parallel processing, whereas `adonis`  seems to suffer from parallel processing. 

The real question is: should this be merged? We do get marginal and overall tests, but with sequential tests of old `adonis` there is no benefit.