### PR TITLE
Return & use (possibly modified) community data when computing WA scores

### DIFF
--- a/R/metaMDS.R
+++ b/R/metaMDS.R
@@ -6,7 +6,13 @@
               plot = FALSE, previous.best,  ...) 
 {
     engine <- match.arg(engine)
-    commname <- deparse(substitute(comm))
+    ## This could be a character vector of length > 1L
+    commname <- deparse(substitute(comm), width.cutoff = 500L)
+    if (length(commname) > 1L) {
+        paste(commname, collapse = "", sep = "")
+        ## deparse can add more white space, so cull 2 or more spaces to a single space
+        commname <- gsub("[ ]{2,}", " ", commname)
+    }
     ## metaMDS was written for community data which should be all
     ## positive. Check this here, and set arguments so that they are
     ## suitable for non-negative data.
@@ -45,13 +51,14 @@
     points <- postMDS(out$points, dis, plot = max(0, plot - 1), ...)
     if (is.null(rownames(points))) 
         rownames(points) <- rownames(comm)
-    if (wascores) {
+    wa <- if (wascores) {
         ## transformed data
-        comm <- eval.parent(parse(text=attr(dis, "commname")))
-        wa <- wascores(points, comm, expand = expand)
+        ##comm <- eval.parent(parse(text=attr(dis, "commname")))
+        comm <- attr(dis, "comm")
+        wascores(points, comm, expand = expand)
+    } else {
+        NA
     }
-    else
-        wa <- NA
     out$points <- points
     out$species <- wa
     out$call <- match.call()

--- a/R/metaMDSdist.R
+++ b/R/metaMDSdist.R
@@ -64,6 +64,7 @@
     }
     attr(dis, "maxdis") <- maxdis
     attr(dis, "commname") <- commname
+    attr(dis, "comm") <- comm
     attr(dis, "function") <- distname
     dis
 }

--- a/tests/vegan-tests.R
+++ b/tests/vegan-tests.R
@@ -228,3 +228,11 @@ all.equal(dat, d, check.attributes = FALSE)
 rm(ind, target, mod, dat, d)
 ### end simulate.*
 
+### test metaMDS works with long expression for comm
+### originally reported to GLS by Richard Telford
+data(varespec)
+set.seed(1)
+mod <- metaMDS(subset(varespec, select = colSums(varespec) > 0, subset = rowSums(varespec) > 0))
+mod
+### The above should run without error & last lines tests changes to the
+### printed output

--- a/tests/vegan-tests.Rout.save
+++ b/tests/vegan-tests.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2015-08-10 r68987) -- "Unsuffered Consequences"
+R version 3.2.0 Patched (2015-05-01 r68289) -- "Full of Ingredients"
 Copyright (C) 2015 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+Platform: x86_64-unknown-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -127,7 +127,7 @@ Permutation: free
 Number of permutations: 99
 
 Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = Use != "Pasture" & spno > 7)
-         Df Variance      F Pr(>F)
+         Df SumOfSqs      F Pr(>F)
 Model     6  1.52798 1.6548   0.11
 Residual  5  0.76948              
 > ## vegan 2.1-40 cannot handle missing data in next two
@@ -141,7 +141,7 @@ Permutation: free
 Number of permutations: 99
 
 Model: capscale(formula = dis ~ Management + poly(A1, 2) + spno, data = df, na.action = na.exclude, subset = object$subset)
-         Df Variance      F Pr(>F)   
+         Df SumOfSqs      F Pr(>F)   
 CAP1      1  0.77834 4.9533   0.01 **
 CAP2      1  0.45691 2.9078   0.03 * 
 CAP3      1  0.14701 0.9355   0.54   
@@ -654,7 +654,56 @@ Number of permutations: 99
 > rm(ind, target, mod, dat, d)
 > ### end simulate.*
 > 
+> ### test metaMDS works with long expression for comm
+> ### originally reported to GLS by Richard Telford
+> data(varespec)
+> set.seed(1)
+> mod <- metaMDS(subset(varespec, select = colSums(varespec) > 0, subset = rowSums(varespec) > 0))
+Square root transformation
+Wisconsin double standardization
+Run 0 stress 0.1843196 
+Run 1 stress 0.2455912 
+Run 2 stress 0.2169407 
+Run 3 stress 0.2313231 
+Run 4 stress 0.1974406 
+Run 5 stress 0.1858402 
+Run 6 stress 0.1948414 
+Run 7 stress 0.2265717 
+Run 8 stress 0.222507 
+Run 9 stress 0.2023215 
+Run 10 stress 0.2673177 
+Run 11 stress 0.1976151 
+Run 12 stress 0.1852397 
+Run 13 stress 0.2341085 
+Run 14 stress 0.1955867 
+Run 15 stress 0.2137409 
+Run 16 stress 0.2109638 
+Run 17 stress 0.1825658 
+... New best solution
+... procrustes: rmse 0.04169825  max resid 0.1521436 
+Run 18 stress 0.1843197 
+Run 19 stress 0.2570119 
+Run 20 stress 0.3760596 
+> mod
+
+Call:
+metaMDS(comm = subset(varespec, select = colSums(varespec) >      0, subset = rowSums(varespec) > 0)) 
+
+global Multidimensional Scaling using monoMDS
+
+Data:     wisconsin(sqrt(subset(varespec, select = colSums(varespec) > 0, subset = rowSums(varespec) > 0))) 
+Distance: bray 
+
+Dimensions: 2 
+Stress:     0.1825658 
+Stress type 1, weak ties
+No convergent solutions - best solution after 20 tries
+Scaling: centring, PC rotation, halfchange scaling 
+Species: expanded scores based on 'wisconsin(sqrt(subset(varespec, select = colSums(varespec) > 0, subset = rowSums(varespec) > 0)))' 
+
+> ### The above should run without error & last lines tests changes to the
+> ### printed output
 > 
 > proc.time()
    user  system elapsed 
-  8.816   0.056   8.864 
+ 56.931   0.274  57.512 


### PR DESCRIPTION
This PR implements a fix for #133. It makes three changes

 1. the (possibly modified) `comm` data is returned from `metaMDSdist()` as attribute `comm` of object `dis`,
 2. computation of WA scores in `metaMDS()` now uses `attr(dis, "comm")` instead of trying to recreate the original data
 3. the deparsed expression passed to the `comm` argument of `metaMDS()` is now robust to very long expressions