### PR TITLE
Multiple plot parameters in ordihull-type functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# History files
+.Rhistory
+
+# Example code in package build process
+*-Ex.R
+
+## ignore backup files
+*~
+

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -32,6 +32,7 @@
     inds <- names(table(groups))
     
     # fill in graphical vectors with default values if unspecified and recycles shorter vectors 
+    col.new <- border.new <- lty.new <- lwd.new <- NULL
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
       if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -2,7 +2,7 @@
     function (ord, groups, display = "sites", kind = c("sd", "se"),
               conf, draw = c("lines", "polygon", "none"),
               w = weights(ord, display), col = NULL, alpha = 127,
-              show.groups, label = FALSE,  ...)
+              show.groups, label = FALSE, border=NULL,lty=NULL, lwd=NULL, ...)
 {
     weights.default <- function(object, ...) NULL
     kind <- match.arg(kind)
@@ -30,6 +30,15 @@
     }
     out <- seq(along = groups)
     inds <- names(table(groups))
+    
+    for(arg in c("col","border","lty","lwd")){
+      tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
+      if(is.null(tmp)) tmp <- 1
+      if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
+      assign(arg, tmp)
+      
+    }
+    
     res <- list()
     if (label) {
         cntrs <- matrix(NA, nrow=length(inds), ncol=2)
@@ -56,10 +65,15 @@
                 xy <- X
             if (draw == "lines")
                 ordiArgAbsorber(xy, FUN = lines,
-                                col = if(is.null(col)) par("fg") else col,
-                                ...)
+                                col = if (is.null(col)) 
+                                  par("fg")
+                                else col[match(is, inds)],
+                                lty=lty[match(is,inds)],lwd=lwd[match(is,inds)], ...)
+                      
             else if (draw == "polygon") 
-                ordiArgAbsorber(xy[, 1], xy[, 2], col = col, FUN = polygon,
+                ordiArgAbsorber(xy[, 1], xy[, 2], col = col[match(is, inds)], border=border[match(is,inds)],
+                                lty=lty[match(is,inds)],lwd=lwd[match(is,inds)],
+                                FUN = polygon,
                                 ...)
             if (label && draw != "none") {
                 cntrs[is,] <- mat$center

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -36,9 +36,14 @@
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
       if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))
       if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
-      assign(arg, tmp)
+      assign(paste(arg,".new", sep=""), tmp)
       
     }
+    # default colour for "polygon" fill is bg, for lines is fg
+    if(is.null(col) && draw=="polygon") {col.new <- rep_len(par("bg"), length(inds))} else
+      if(is.null(col) && draw=="lines") {col.new <- rep_len(par("fg"), length(inds))}
+      
+  
     
     res <- list()
     if (label) {
@@ -68,12 +73,12 @@
                 ordiArgAbsorber(xy, FUN = lines,
                                 col = if (is.null(col)) 
                                   par("fg")
-                                else col[match(is, inds)],
-                                lty=lty[match(is,inds)],lwd=lwd[match(is,inds)], ...)
+                                else col.new[match(is, inds)],
+                                lty=lty.new[match(is,inds)],lwd=lwd.new[match(is,inds)], ...)
                       
             else if (draw == "polygon") 
-                ordiArgAbsorber(xy[, 1], xy[, 2], col = col[match(is, inds)], border=border[match(is,inds)],
-                                lty=lty[match(is,inds)],lwd=lwd[match(is,inds)],
+                ordiArgAbsorber(xy[, 1], xy[, 2], col = col.new[match(is, inds)], border=border.new[match(is,inds)],
+                                lty=lty.new[match(is,inds)],lwd=lwd.new[match(is,inds)],
                                 FUN = polygon,
                                 ...)
             if (label && draw != "none") {
@@ -86,7 +91,7 @@
     if (label && draw != "none") {
         if (draw == "lines")
             ordiArgAbsorber(cntrs[,1], cntrs[,2], labels = rownames(cntrs),
-                            col = col,  FUN = text, ...)
+                            col = col.new,  FUN = text, ...)
         else 
             ordiArgAbsorber(cntrs, col = NULL,
                             FUN = ordilabel, ...)

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -34,7 +34,7 @@
     # fill in graphical vectors with default values if unspecified and recycles shorter vectors 
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
-      if(is.null(tmp)) tmp <- 1
+      if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))
       if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
       assign(arg, tmp)
       

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -39,8 +39,8 @@
       assign(paste(arg,".new", sep=""), tmp)
       
     }
-    # default colour for "polygon" fill is bg, for lines is fg
-    if(is.null(col) && draw=="polygon") {col.new <- rep_len(par("bg"), length(inds))} else
+    # default colour for "polygon" fill is "transparent", for lines is par("fg")
+    if(is.null(col) && draw=="polygon") {col.new <- rep_len("transparent", length(inds))} else
       if(is.null(col) && draw=="lines") {col.new <- rep_len(par("fg"), length(inds))}
       
   

--- a/R/ordiellipse.R
+++ b/R/ordiellipse.R
@@ -31,6 +31,7 @@
     out <- seq(along = groups)
     inds <- names(table(groups))
     
+    # fill in graphical vectors with default values if unspecified and recycles shorter vectors 
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
       if(is.null(tmp)) tmp <- 1

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -32,7 +32,7 @@
     # fill in graphical vectors with default values if unspecified and recycles shorter vectors    
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
-      if(is.null(tmp)) tmp <- 1
+      if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))
       if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
       assign(arg, tmp)
       

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -37,8 +37,8 @@
       assign(paste(arg,".new", sep=""), tmp)
       
     }
-    # default colour for "polygon" fill is bg, for lines is fg
-    if(is.null(col) && draw=="polygon") {col.new <- rep_len(par("bg"), length(inds))} else
+    # default colour for "polygon" fill is "transparent", for lines is par("fg")
+    if(is.null(col) && draw=="polygon") {col.new <- rep_len("transparent", length(inds))} else
       if(is.null(col) && draw=="lines") {col.new <- rep_len(par("fg"), length(inds))}
     
     

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -29,14 +29,18 @@
     out <- seq(along = groups)
     inds <- names(table(groups))
     
-    # fill in graphical vectors with default values if unspecified and recycles shorter vectors    
+    # fill in graphical vectors with default values if unspecified and recycles shorter vectors 
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
       if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))
       if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
-      assign(arg, tmp)
+      assign(paste(arg,".new", sep=""), tmp)
       
     }
+    # default colour for "polygon" fill is bg, for lines is fg
+    if(is.null(col) && draw=="polygon") {col.new <- rep_len(par("bg"), length(inds))} else
+      if(is.null(col) && draw=="lines") {col.new <- rep_len(par("fg"), length(inds))}
+    
     
     res <- list()
     if (label) {
@@ -54,9 +58,9 @@
             if (draw == "lines") 
               ordiArgAbsorber(X[hpts, ], FUN = lines, col = if (is.null(col)) 
                 par("fg")
-                else col[match(is, inds)], lty=lty[match(is,inds)],lwd=lwd[match(is,inds)], ...)
+                else col.new[match(is, inds)], lty=lty.new[match(is,inds)],lwd=lwd.new[match(is,inds)], ...)
             else if (draw == "polygon") 
-              ordiArgAbsorber(X[hpts, ], border = border[match(is,inds)],FUN = polygon, col = col[match(is, inds)], ...)
+              ordiArgAbsorber(X[hpts, ], border = border.new[match(is,inds)],FUN = polygon, col = col.new[match(is, inds)], ...)
             if (label && draw != "none") {
                 cntrs[is,] <- polycentre(X[hpts,])
             }
@@ -66,7 +70,7 @@
     if (label && draw != "none") {
       if (draw == "lines") 
         ordiArgAbsorber(cntrs[, 1], cntrs[, 2], labels = names, 
-                        col = col[match(is, inds)], FUN = text, ...)
+                        col = col.new[match(is, inds)], FUN = text, ...)
       else ordiArgAbsorber(cntrs, labels = names, col = NULL, 
                            FUN = ordilabel, ...)
     }

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -29,6 +29,7 @@
     out <- seq(along = groups)
     inds <- names(table(groups))
     
+    # fill in graphical vectors with default values if unspecified and recycles shorter vectors    
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
       if(is.null(tmp)) tmp <- 1

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -1,7 +1,9 @@
 `ordihull` <-
     function (ord, groups, display = "sites",
               draw = c("lines", "polygon", "none"),
-              col = NULL, alpha = 127, show.groups, label = FALSE, ...)
+              col = NULL, alpha = 127, show.groups, label = FALSE,
+              border=NULL, lty=NULL, lwd=NULL, ...)
+      
 {
     draw <- match.arg(draw)
     ## Internal function to find the polygon centre
@@ -26,6 +28,15 @@
     }
     out <- seq(along = groups)
     inds <- names(table(groups))
+    
+    for(arg in c("col","border","lty","lwd")){
+      tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
+      if(is.null(tmp)) tmp <- 1
+      if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
+      assign(arg, tmp)
+      
+    }
+    
     res <- list()
     if (label) {
         cntrs <- matrix(NA, nrow=length(inds), ncol=2)
@@ -39,11 +50,12 @@
             X <- pts[gr,, drop = FALSE]
             hpts <- chull(X)
             hpts <- c(hpts, hpts[1])
-            if (draw == "lines")
-                ordiArgAbsorber(X[hpts, ], FUN = lines,
-                                col = if(is.null(col)) par("fg") else col, ...)
-            else if (draw == "polygon")
-                ordiArgAbsorber(X[hpts,], FUN = polygon, col = col, ...)
+            if (draw == "lines") 
+              ordiArgAbsorber(X[hpts, ], FUN = lines, col = if (is.null(col)) 
+                par("fg")
+                else col[match(is, inds)], lty=lty[match(is,inds)],lwd=lwd[match(is,inds)], ...)
+            else if (draw == "polygon") 
+              ordiArgAbsorber(X[hpts, ], border = border[match(is,inds)],FUN = polygon, col = col[match(is, inds)], ...)
             if (label && draw != "none") {
                 cntrs[is,] <- polycentre(X[hpts,])
             }
@@ -51,12 +63,11 @@
         }
     }
     if (label && draw != "none") {
-        if (draw == "lines")
-            ordiArgAbsorber(cntrs[,1], cntrs[,2], labels = rownames(cntrs),
-                            col = col, FUN = text, ...)
-        else
-            ordiArgAbsorber(cntrs, col = NULL,
-                            FUN = ordilabel, ...)
+      if (draw == "lines") 
+        ordiArgAbsorber(cntrs[, 1], cntrs[, 2], labels = names, 
+                        col = col[match(is, inds)], FUN = text, ...)
+      else ordiArgAbsorber(cntrs, labels = names, col = NULL, 
+                           FUN = ordilabel, ...)
     }
     class(res) <- "ordihull"
     invisible(res)

--- a/R/ordihull.R
+++ b/R/ordihull.R
@@ -30,6 +30,7 @@
     inds <- names(table(groups))
     
     # fill in graphical vectors with default values if unspecified and recycles shorter vectors 
+    col.new <- border.new <- lty.new <- lwd.new <- NULL
     for(arg in c("col","border","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
       if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))

--- a/R/ordispider.R
+++ b/R/ordispider.R
@@ -1,7 +1,7 @@
 `ordispider` <-
     function (ord, groups, display = "sites", w = weights(ord, display),
               spiders = c("centroid", "median"),
-              show.groups, label = FALSE, ...)
+              show.groups, label = FALSE,col=NULL, lty=NULL, lwd=NULL, ...)
 {
     weights.default <- function(object, ...) NULL
     spiders <- match.arg(spiders)
@@ -38,6 +38,15 @@
     inds <- names(table(groups))
     if (label) 
     cntrs <- names <- NULL
+    
+    # fill in graphical vectors with default values if unspecified and recycles shorter vectors    
+    for(arg in c("col","lty","lwd")){
+      tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
+      if(is.null(tmp)) tmp <- 1
+      if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
+      assign(arg, tmp)
+      
+    }
     ## 'kk' removes NA scores and NA groups
     kk <- complete.cases(pts) & !is.na(groups)
     for (is in inds) {
@@ -50,7 +59,8 @@
                               "centroid" = apply(X, 2, weighted.mean, w = W),
                               "median" = ordimedian(X, rep(1, nrow(X))))
                 ordiArgAbsorber(ave[1], ave[2], X[, 1], X[, 2],
-                                FUN = segments, ...)
+                                FUN = segments, col[match(is, inds)],
+                                lty=lty[match(is,inds)],lwd=lwd[match(is,inds)],...)
             } else {
                 ave <- X
             }

--- a/R/ordispider.R
+++ b/R/ordispider.R
@@ -42,7 +42,7 @@
     # fill in graphical vectors with default values if unspecified and recycles shorter vectors    
     for(arg in c("col","lty","lwd")){
       tmp <- mget(arg,ifnotfound=list(NULL))[[1]]
-      if(is.null(tmp)) tmp <- 1
+      if(is.null(tmp)) tmp <- ifelse(suppressWarnings(is.null(par(arg))), par("fg"), par(arg))
       if(length(inds) != length(tmp)) {tmp <- rep_len(tmp, length(inds))}
       assign(arg, tmp)
       

--- a/man/ordihull.Rd
+++ b/man/ordihull.Rd
@@ -20,13 +20,15 @@
 
 \usage{
 ordihull(ord, groups, display = "sites", draw = c("lines","polygon", "none"),
-         col = NULL, alpha = 127, show.groups, label = FALSE,  ...)
+         col = NULL, alpha = 127, show.groups, label = FALSE, lty=NULL,
+         lwd=NULL, ...)
 ordiellipse(ord, groups, display="sites", kind = c("sd","se"), conf,
          draw = c("lines","polygon", "none"), w = weights(ord, display),
-         col = NULL, alpha = 127, show.groups, label = FALSE, ...)
+         col = NULL, alpha = 127, show.groups, label = FALSE, lty=NULL,
+         lwd=NULL, border=NULL,...)
 ordispider(ord, groups, display="sites", w = weights(ord, display),
 	 spiders = c("centroid", "median"),  show.groups, 
-         label = FALSE, ...)
+         label = FALSE, col=NULL, lty=NULL, lwd=NULL, ...)
 ordicluster(ord, cluster, prune = 0, display = "sites",
          w = weights(ord, display), ...)
 \method{summary}{ordihull}(object, ...)
@@ -114,6 +116,10 @@ ordiareatest(ord, groups, area = c("hull", "ellipse"), permutations = 999,
     cluster.  With \code{parallel = 1} uses ordinary, non-parallel
     processing. The parallel processing is done with \pkg{parallel}
     package.}
+    
+  \item{lty, lwd, lwd, border}{Vectors of these parameters can be supplied
+  and will be applied (if appropriate) for each element of \code{names(table(groups))}
+  (in that order). Shorter vectors will be recycled.}
 
   \item{\dots}{Parameters passed to graphical functions or to
     \code{\link{scores}} to select axes and scaling etc. } 

--- a/man/ordihull.Rd
+++ b/man/ordihull.Rd
@@ -52,7 +52,10 @@ ordiareatest(ord, groups, area = c("hull", "ellipse"), permutations = 999,
     \code{ordiellipse}.  When \code{draw = "polygon"}, the colour of
     bordering lines can be set with argument \code{border} of the
     \code{\link{polygon}} function. For other functions the effect
-    depends on the underlining functions this argument is passed to.}
+    depends on the underlining functions this argument is passed to.
+    When multiple values of \code{col} are specified these are used for
+    each element of \code{levels(factor(groups))} (in that order), shorter
+    vectors are recycled.}
 
   \item{alpha}{Transparency of the fill \code{col}our with \code{draw
     = "polygon"} in \code{ordihull} and \code{ordiellipse}.  The

--- a/man/ordihull.Rd
+++ b/man/ordihull.Rd
@@ -54,7 +54,7 @@ ordiareatest(ord, groups, area = c("hull", "ellipse"), permutations = 999,
     \code{\link{polygon}} function. For other functions the effect
     depends on the underlining functions this argument is passed to.
     When multiple values of \code{col} are specified these are used for
-    each element of \code{levels(factor(groups))} (in that order), shorter
+    each element of \code{names(table(groups))} (in that order), shorter
     vectors are recycled.}
 
   \item{alpha}{Transparency of the fill \code{col}our with \code{draw


### PR DESCRIPTION
Dear Jari,

I wrote to you about 18 months about this idea. Sorry it has taken me so long to implement it! From my earlier email:

> One task I often use `vegan` for is plotting ordinations showing multiple ordihulls. I often like to give these hulls different colours and/or line types. I am rather lazy and to save myself some typing I altered the original ordihull function to allow the specification of multiple values for col, lty, lwd and border – recycling as necessary over the levels of ‘groups’. (thus avoiding multiple calls to ordihull and the show.groups argument).

In response to your questions from back then, the arguments are applied in the order of `names(table(groups))`, and will also (without warning) count groups of 1 element which do not get ellipses/hulls/spiders plotted for them. Vectors are recycled if shorter than `length(table(groups))` and I've tried to ensure that parameter values are taken from `par()` when not specified by the user.

This is how it looks:

```r
data(dune)
data(dune.env)
ord <- metaMDS(dune)

old <- par(mfrow=c(1,2))
ordiplot(ord, type="n")
ordiellipse(ord, groups = dune.env$Use, draw="polygon",
 col=c("red", "blue", "green"), border=NA)

ordiplot(ord, type="n")
ordihull(ord, groups = dune.env$Use, draw="polygon",alpha=200,
 col=c("lightgrey", "lightblue", "lightgreen"), lty=c(2,1,3), lwd=c(2,1,2))

par(old)
```

![image](https://cloud.githubusercontent.com/assets/1643942/9658999/c26611c6-524d-11e5-9120-2a8d6b28d301.png)

`show.groups` still works (hopefully) as expected

```r
ordiplot(ord, type="n")
ordihull(ord, groups = dune.env$Use, draw="polygon",alpha=200, col=c("lightgrey", "lightblue"),
 lty=c(2,1), lwd=2, show.groups = c("Haypastu","Hayfield"))
```

![image](https://cloud.githubusercontent.com/assets/1643942/9659098/842400a2-524e-11e5-89b2-b78bbe9b0ca1.png)


I look forward to your feedback. Also since this is my first 'pull request' - please let me know if I have done anything wrong procedure-wise.

