### PR TITLE
rrarefy behaviour

### DIFF
--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -14,6 +14,9 @@
     sample <- rep(sample, length=nrow(x))
     colnames(x) <- colnames(x, do.NULL = FALSE)
     nm <- colnames(x)
+    ## warn if something cannot be rarefied
+    if (any(rowSums(x) < sample))
+        warning("Some row sums < 'sample' and are not rarefied")
     for (i in 1:nrow(x)) {
         if (sum(x[i,]) <= sample[i]) ## nothing to rarefy: take all
             next
@@ -35,8 +38,15 @@
         stop("function accepts only integers (counts)")
     if (length(sample) > 1 &&  length(sample) != nrow(x))
         stop(gettextf(
-             "length of  'sample' and number of rows of 'x' do not match"))
+             "length of 'sample' and number of rows of 'x' do not match"))
     x <- drop(as.matrix(x))
+    ## warn on too large samples
+    if (is.matrix(x))
+        rs <- rowSums(x)
+    else
+        rs <- sum(x)
+    if (any(rs) < sample)
+        warning("'sample' larger than community: all probabilities 0 or 1")
     ## dfun is kluge: first item of  vector x must be the sample size,
     ## and the rest  is the community data. This  seemed an easy trick
     ## to evaluate dfun in an apply() instead of a loop.

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -50,7 +50,7 @@
     ## dfun is kluge: first item of  vector x must be the sample size,
     ## and the rest  is the community data. This  seemed an easy trick
     ## to evaluate dfun in an apply() instead of a loop.
-    dfun <- function(x, sample) {
+    dfun <- function(x) {
         J <- sum(x[-1])
         sample <- min(x[1], J)
         1 - exp(lchoose(J - x[-1], sample) - lchoose(J, sample))

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -46,7 +46,7 @@
     else
         rs <- sum(x)
     if (any(rs) < sample)
-        warning("(Some) 'sample' larger than community: probabilities either 0 or 1")
+        warning("Some row sums < 'sample' and probabilities either 0 or 1")
     ## dfun is kluge: first item of  vector x must be the sample size,
     ## and the rest  is the community data. This  seemed an easy trick
     ## to evaluate dfun in an apply() instead of a loop.

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -15,6 +15,8 @@
     colnames(x) <- colnames(x, do.NULL = FALSE)
     nm <- colnames(x)
     for (i in 1:nrow(x)) {
+        if (sum(x[i,]) <= sample[i]) ## nothing to rarefy: take all
+            next
         row <- sample(rep(nm, times=x[i,]), sample[i])
         row <- table(row)
         ind <- names(row)

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -46,7 +46,7 @@
     else
         rs <- sum(x)
     if (any(rs) < sample)
-        warning("'sample' larger than community: all probabilities 0 or 1")
+        warning("(Some) 'sample' larger than community: probabilities either 0 or 1")
     ## dfun is kluge: first item of  vector x must be the sample size,
     ## and the rest  is the community data. This  seemed an easy trick
     ## to evaluate dfun in an apply() instead of a loop.

--- a/man/rarefy.Rd
+++ b/man/rarefy.Rd
@@ -47,17 +47,20 @@ rareslope(x, sample)
   \code{rarefy} is based on Hurlbert's (1971) formulation, and the
   standard errors on Heck et al. (1975).
 
-  Function \code{rrarefy} generates one randomly rarefied community data
-  frame or vector of given \code{sample} size. The \code{sample} can be
-  a vector giving the sample sizes for each row, and its values must be
-  less or equal to observed number of individuals. The random
-  rarefaction is made without replacement so that the variance of
-  rarefied communities is rather related to rarefaction proportion than
-  to to the size of the \code{sample}.
+  Function \code{rrarefy} generates one randomly rarefied community
+  data frame or vector of given \code{sample} size. The \code{sample}
+  can be a vector giving the sample sizes for each row.  If the
+  \code{sample} size is equal to or smaller than the observed number
+  of individuals, the non-rarefied community will be returned.  The
+  random rarefaction is made without replacement so that the variance
+  of rarefied communities is rather related to rarefaction proportion
+  than to the size of the \code{sample}.
 
-  Function \code{drarefy} returns probabilities that species occur in a
-  rarefied community of size \code{sample}. The \code{sample} can be a
-  vector giving the sample sizes for each row.
+  Function \code{drarefy} returns probabilities that species occur in
+  a rarefied community of size \code{sample}. The \code{sample} can be
+  a vector giving the sample sizes for each row. If the \code{sample}
+  is equal to or smaller than the observed number of individuals, all
+  observed species will have sampling probability 1.
 
   Function \code{rarecurve} draws a rarefaction curve for each row of
   the input data. The rarefaction curves are evaluated using the


### PR DESCRIPTION
This PR responds concerns in issue #144:

* `rrarefy` will work when `sample` > row sum and return non-rarefied row. This is consistent with the current behaviour in `rarefy` and `drarefy`.
* both `rrarefy` and `drarefy` will issue a warning when `sample` > row sum so that users know they may need to handle the issue. This is consistent with `rarefy`.