### PR TITLE
Fix partial matching in load hook

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onAttach <- function(lib, pkg)  {
     packageStartupMessage("This is vegan ",
                           utils::packageDescription("vegan",
-                                                    field="Version"),
+                                                    fields="Version"),
                           appendLF = TRUE)
 }


### PR DESCRIPTION
As is, this triggers a warning on package load when using
`options(warnPartialMatchArgs=TRUE)`.