### PR TITLE
This PR implements an adjusted R2 calculation for cca

### DIFF
--- a/R/RsquareAdj.R
+++ b/R/RsquareAdj.R
@@ -35,10 +35,10 @@
 
 ## cca result: no RsquareAdj
 RsquareAdj.cca <-
-    function (x, nperm = 1000) 
+    function (x, permutations = 1000, ...) 
 {
     r2 <- x$CCA$tot.chi / x$tot.chi
-    p <- permutest(x, nperm)
+    p <- permutest(x, permutations, ...)
     radj <- 1 - ((1 - r2) / (1 - mean(p$num / x$tot.chi)))
     list(r.squared = r2, adj.r.squared = radj)
 }

--- a/R/RsquareAdj.R
+++ b/R/RsquareAdj.R
@@ -35,11 +35,30 @@
 
 ## cca result: no RsquareAdj
 RsquareAdj.cca <-
-    function(x, ...)
+    function(x, nperm, print_progress=TRUE, ...)
 {
-    R2 <- x$CCA$tot.chi/x$tot.chi
-    radj <- NA
-    list(r.squared = R2, adj.r.squared = radj)
+    r2 <- x$CCA$tot.chi/x$tot.chi
+    n <- nrow(x$CCA$u)
+    rand_r2 <- rep(NA, nperm)
+    Y_string <- as.character(x$terms[[2]])
+    Y <- eval(parse(text=Y_string))
+    Y_name <- strsplit(as.character(x$call[2]), ' ~ ')[[1]][1]
+    x$call[2] <- sub(Y_name, 'Y_rand', x$call[2])
+    for (i in 1:nperm) {
+        Y_rand <- Y[sample(n), ]
+        cca_rand <- eval(parse(text=paste(x$call[1], '(',x$call[2], 
+                                         ', data=', x$call[3], ')', 
+                                         sep='')))
+        rand_r2[i] <- cca_rand$CCA$tot.chi / x$tot.chi
+        if (print_progress) {
+            if (i %% 100 == 0)  
+                print(paste('perm:', i, 'adj.r.squared:', 
+                            round(1 - ((1 - r2) / (1 - mean(rand_r2, na.rm=T))),3)))
+        }
+    }
+    # Eq 5 Peres-Neto et al. 2006
+    radj <- 1 - ((1 - r2) / (1 - mean(rand_r2)))
+    list(r.squared = r2, adj.r.squared = radj)
 }
 
 ## Linear model: take the result from the summary

--- a/R/RsquareAdj.R
+++ b/R/RsquareAdj.R
@@ -42,8 +42,7 @@ RsquareAdj.cca <-
     rand_r2 <- rep(NA, nperm)
     Y_string <- as.character(x$terms[[2]])
     Y <- eval(parse(text=Y_string))
-    Y_name <- strsplit(as.character(x$call[2]), ' ~ ')[[1]][1]
-    x$call[2] <- sub(Y_name, 'Y_rand', x$call[2])
+    x$call[2] <- sub(Y_string, 'Y_rand', x$call[2])
     for (i in 1:nperm) {
         Y_rand <- Y[sample(n), ]
         cca_rand <- eval(parse(text=paste(x$call[1], '(',x$call[2], 

--- a/R/RsquareAdj.R
+++ b/R/RsquareAdj.R
@@ -35,28 +35,11 @@
 
 ## cca result: no RsquareAdj
 RsquareAdj.cca <-
-    function(x, nperm, print_progress=TRUE, ...)
+    function (x, nperm = 1000) 
 {
-    r2 <- x$CCA$tot.chi/x$tot.chi
-    n <- nrow(x$CCA$u)
-    rand_r2 <- rep(NA, nperm)
-    Y_string <- as.character(x$terms[[2]])
-    Y <- eval(parse(text=Y_string))
-    x$call[2] <- sub(Y_string, 'Y_rand', x$call[2])
-    for (i in 1:nperm) {
-        Y_rand <- Y[sample(n), ]
-        cca_rand <- eval(parse(text=paste(x$call[1], '(',x$call[2], 
-                                         ', data=', x$call[3], ')', 
-                                         sep='')))
-        rand_r2[i] <- cca_rand$CCA$tot.chi / x$tot.chi
-        if (print_progress) {
-            if (i %% 100 == 0)  
-                print(paste('perm:', i, 'adj.r.squared:', 
-                            round(1 - ((1 - r2) / (1 - mean(rand_r2, na.rm=T))),3)))
-        }
-    }
-    # Eq 5 Peres-Neto et al. 2006
-    radj <- 1 - ((1 - r2) / (1 - mean(rand_r2)))
+    r2 <- x$CCA$tot.chi / x$tot.chi
+    p <- permutest(x, nperm)
+    radj <- 1 - ((1 - r2) / (1 - mean(p$num / x$tot.chi)))
     list(r.squared = r2, adj.r.squared = radj)
 }
 

--- a/man/RsquareAdj.Rd
+++ b/man/RsquareAdj.Rd
@@ -17,6 +17,7 @@ Adjusted R-square
 \usage{
 \method{RsquareAdj}{default}(x, n, m, ...)
 \method{RsquareAdj}{rda}(x, ...)
+\method{RsquareAdj}{cca}(x, nperm, print_progress=TRUE, ...)
 }
 
 \arguments{
@@ -38,10 +39,13 @@ Adjusted R-square
   \code{\link{cca}}, \code{\link{lm}} and \code{\link{glm}}. Adjusted,
   or even unadjusted, R-squared may not be available in some cases,
   and then the functions will return \code{NA}. There is no adjusted
-  R-squared in \code{\link{cca}}, in partial \code{\link{rda}}, and
+  in partial \code{\link{rda}}, and
   R-squared values are available only for \code{\link{gaussian}}
   models in \code{\link{glm}}.
 
+  The adjusted, \eqn{R^2}{R-squared} of \code{cca} is computed using a 
+  permutation approach developed by Peres-Neto et al. (2006). 
+  
   The raw \eqn{R^2}{R-squared} of partial \code{rda} gives the
   proportion explained after removing the variation due to conditioning
   (partial) terms; Legendre et al. (2011) call this semi-partial

--- a/man/RsquareAdj.Rd
+++ b/man/RsquareAdj.Rd
@@ -17,7 +17,7 @@ Adjusted R-square
 \usage{
 \method{RsquareAdj}{default}(x, n, m, ...)
 \method{RsquareAdj}{rda}(x, ...)
-\method{RsquareAdj}{cca}(x, nperm = 1000, ...)
+\method{RsquareAdj}{cca}(x, permutations = 1000, ...)
 }
 
 \arguments{
@@ -28,10 +28,12 @@ Adjusted R-square
   \item{n, m}{Number of observations and number of degrees of freedom
   in the fitted model.}
   
-  \item{nperm}{Number of permutations to use when computing the adjusted 
-  R-squared for a cca.}
+  \item{permutations}{Number of permutations to use when computing the adjusted 
+  R-squared for a cca. The permutations can be calculated in parallel by
+  specifying the number of cores which is passed to \code{\link{permutest}}}
 
-  \item{\dots}{ Other arguments (ignored).} 
+  \item{\dots}{ Other arguments (ignored) except in the case of cca in 
+  which these arguments are passed to \code{\link{permutest}}.} 
 }
 
 \details{ The default method finds the adjusted

--- a/man/RsquareAdj.Rd
+++ b/man/RsquareAdj.Rd
@@ -17,7 +17,7 @@ Adjusted R-square
 \usage{
 \method{RsquareAdj}{default}(x, n, m, ...)
 \method{RsquareAdj}{rda}(x, ...)
-\method{RsquareAdj}{cca}(x, nperm, print_progress=TRUE, ...)
+\method{RsquareAdj}{cca}(x, nperm = 1000, ...)
 }
 
 \arguments{
@@ -27,6 +27,9 @@ Adjusted R-square
   
   \item{n, m}{Number of observations and number of degrees of freedom
   in the fitted model.}
+  
+  \item{nperm}{Number of permutations to use when computing the adjusted 
+  R-squared for a cca.}
 
   \item{\dots}{ Other arguments (ignored).} 
 }
@@ -44,7 +47,8 @@ Adjusted R-square
   models in \code{\link{glm}}.
 
   The adjusted, \eqn{R^2}{R-squared} of \code{cca} is computed using a 
-  permutation approach developed by Peres-Neto et al. (2006). 
+  permutation approach developed by Peres-Neto et al. (2006). By default 1000
+  permutations are used.
   
   The raw \eqn{R^2}{R-squared} of partial \code{rda} gives the
   proportion explained after removing the variation due to conditioning
@@ -79,6 +83,9 @@ data(mite)
 data(mite.env)
 ## rda
 m <- rda(decostand(mite, "hell") ~  ., mite.env)
+RsquareAdj(m)
+## cca
+m <- cca(decostand(mite, "hell") ~  ., mite.env)
 RsquareAdj(m)
 ## default method
 RsquareAdj(0.8, 20, 5)


### PR DESCRIPTION
Based on conversations in #161 I decided to provide code for implementing the permutation based approach of adjusting the R2 calculation for cca that was developed by Peres-Neto et al 2006. There are currently some limitations of my implementation (see commit log). I'm happy to work to overcome these limitations ironed out so that this method can be more fully realized, but I'll likely need some suggestions for how to do this.