### PR TITLE
pch= and col= args added to plot.betadisper()

### DIFF
--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -1,5 +1,5 @@
 `plot.betadisper` <- function(x, axes = c(1,2), 
-                              cex = 0.7, pch = 1:ng,
+                              cex = 0.7, pch = 1:ng, col=rep(palette()[-1], ng),
                               hull = TRUE,
                               ylab, xlab, main, sub, ...)
 {
@@ -16,6 +16,7 @@
         ylab <- paste("PCoA", axes[2])
     g <- scores(x, choices = axes)
     ng <- length(levels(x$group))
+    col <- rep_len(col, ng)  # make sure there are enough colors
     plot(g$sites, asp = 1, type = "n", axes = FALSE, ann = FALSE, ...)
     ## if more than 1 group level
     if(is.matrix(g$centroids)) {
@@ -45,7 +46,7 @@
         points(g$centroids[1L], g$centroids[1L],
                pch = 16, cex = 1, col = "red", ...)
     }
-    points(g$sites, pch = pch[x$group], cex = cex, ...)
+    points(g$sites, pch = pch[x$group], cex = cex, col=col[x$group], ...)
     localTitle(main = main, xlab = xlab, ylab = ylab, sub = sub, ...)
     localAxis(1, ...)
     localAxis(2, ...)

--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -1,4 +1,6 @@
-`plot.betadisper` <- function(x, axes = c(1,2), cex = 0.7, hull = TRUE,
+`plot.betadisper` <- function(x, axes = c(1,2), 
+                              cex = 0.7, pch = 1:ng,
+                              hull = TRUE,
                               ylab, xlab, main, sub, ...)
 {
     localAxis <- function(..., col, bg, pch, cex, lty, lwd) axis(...)
@@ -13,6 +15,7 @@
     if(missing(ylab))
         ylab <- paste("PCoA", axes[2])
     g <- scores(x, choices = axes)
+    ng <- length(levels(x$group))
     plot(g$sites, asp = 1, type = "n", axes = FALSE, ann = FALSE, ...)
     ## if more than 1 group level
     if(is.matrix(g$centroids)) {
@@ -42,7 +45,7 @@
         points(g$centroids[1L], g$centroids[1L],
                pch = 16, cex = 1, col = "red", ...)
     }
-    points(g$sites, pch = as.numeric(x$group), cex = cex, ...)
+    points(g$sites, pch = pch[x$group], cex = cex, ...)
     localTitle(main = main, xlab = xlab, ylab = ylab, sub = sub, ...)
     localAxis(1, ...)
     localAxis(2, ...)

--- a/man/betadisper.Rd
+++ b/man/betadisper.Rd
@@ -36,7 +36,8 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE)
 
 \method{eigenvals}{betadisper}(x, \dots)
 
-\method{plot}{betadisper}(x, axes = c(1,2), cex = 0.7, pch = as.numeric(x$group), 
+\method{plot}{betadisper}(x, axes = c(1,2), cex = 0.7, 
+     pch = 1:ng, col=rep(palette()[-1], ng),
      hull = TRUE,
      ylab, xlab, main, sub, \dots)
 
@@ -64,6 +65,7 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE)
   \item{choices, axes}{the principal coordinate axes wanted.}
   \item{hull}{logical; should the convex hull for each group be plotted?}
   \item{pch}{plot symbols for the groups, a vector of length equal to the number of groups}
+  \item{col}{colors for the plot symbols for the groups, a vector of length equal to the number of groups}
   \item{cex, ylab, xlab, main, sub}{graphical parameters. For details,
     see \code{\link{plot.default}}.}
   \item{which}{A character vector listing terms in the fitted model for

--- a/man/betadisper.Rd
+++ b/man/betadisper.Rd
@@ -36,7 +36,8 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE)
 
 \method{eigenvals}{betadisper}(x, \dots)
 
-\method{plot}{betadisper}(x, axes = c(1,2), cex = 0.7, hull = TRUE,
+\method{plot}{betadisper}(x, axes = c(1,2), cex = 0.7, pch = as.numeric(x$group), 
+     hull = TRUE,
      ylab, xlab, main, sub, \dots)
 
 \method{boxplot}{betadisper}(x, ylab = "Distance to centroid", ...)
@@ -62,6 +63,7 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE)
     call to \code{betadisper}.}
   \item{choices, axes}{the principal coordinate axes wanted.}
   \item{hull}{logical; should the convex hull for each group be plotted?}
+  \item{pch}{plot symbols for the groups, a vector of length equal to the number of groups}
   \item{cex, ylab, xlab, main, sub}{graphical parameters. For details,
     see \code{\link{plot.default}}.}
   \item{which}{A character vector listing terms in the fitted model for


### PR DESCRIPTION
In response to issue #128 and for my needs, I added basic capability to set pch= and col=
for the points plotted for groups.  There are still quite a few other graphical parameters hardcoded,
but I resisted the temptation to go further in this round.
