### PR TITLE
add option to draw confidence ellipses to group centroids

### DIFF
--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -1,10 +1,26 @@
 `plot.betadisper` <- function(x, axes = c(1,2), cex = 0.7, pch = seq_len(ng),
                               col = NULL, hull = TRUE,
+                              ellipse = FALSE, ellipse.type = c("sd","se"),
+                              ellipse.conf = NULL,
                               ylab, xlab, main, sub, ...)
 {
     localAxis <- function(..., col, bg, pch, cex, lty, lwd) axis(...)
     localBox <- function(..., col, bg, pch, cex, lty, lwd) box(...)
     localTitle <- function(..., col, bg, pch, cex, lty, lwd) title(...)
+    Ellipse <- function(scrs, type, conf, col, lty, lwd) {
+        mat <- cov.wt(scrs, wt = rep_len(1, nrow(scrs)))
+        if (mat$n.obs == 1)
+            mat$cov[] <- 0
+        if (type == "se") {
+            mat$cov <- mat$cov * sum(mat$wt^2)
+        }
+        xy <- if (mat$n.obs > 1) {
+                  veganCovEllipse(mat$cov, mat$center, conf)
+        } else {
+            scrs
+        }
+        ordiArgAbsorber(xy, FUN = lines, col = col, lty = lty, lwd = lwd)
+    }
     if(missing(main))
         main <- deparse(substitute(x))
     if(missing(sub))
@@ -13,8 +29,15 @@
         xlab <- paste("PCoA", axes[1])
     if(missing(ylab))
         ylab <- paste("PCoA", axes[2])
+    ellipse.type <- match.arg(ellipse.type)
+    conf <- if (missing(ellipse.conf)) {
+        1
+    } else {
+        sqrt(qchisq(conf, 2))
+    }
     g <- scores(x, choices = axes)
     ng <- length(levels(x$group))
+    lev <- levels(x$group)
     ## sort out colour vector if none supplied
     if (is.null(col)) {
         col <- palette()
@@ -23,16 +46,22 @@
     plot(g$sites, asp = 1, type = "n", axes = FALSE, ann = FALSE, ...)
     ## if more than 1 group level
     if(is.matrix(g$centroids)) {
-        for(i in levels(x$group)) {
-            j <- which(levels(x$group) == i)
+        for(i in seq_along(lev)) {
+            curlev <- lev[i]
+            take <- x$group == curlev
+            j <- which(lev == curlev)
             segments(g$centroids[j, 1L], g$centroids[j, 2L],
-                     g$sites[x$group == i, 1L],
-                     g$sites[x$group == i, 2L], col = "blue", ...)
+                     g$sites[take, 1L],
+                     g$sites[take, 2L], col = "blue", ...)
             if(hull) {
-                ch <- chull(g$sites[x$group == i, ])
+                ch <- chull(g$sites[take, ])
                 ch <- c(ch, ch[1])
-                lines(x$vectors[x$group == i, axes][ch, ],
-                      col = "black", lty = "dashed", ...)
+                lines(x$vectors[take, axes][ch, ],
+                      col = col[i], lty = "dashed", ...)
+            }
+            if (ellipse) {
+                Ellipse(g$sites[take, , drop = FALSE], type = ellipse.type,
+                        conf = conf, col = col[i], lty = 1, lwd = 1)
             }
         }
         points(g$centroids, pch = 16, cex = 1, col = "red", ...)
@@ -44,7 +73,11 @@
             ch <- chull(g$sites)
             ch <- c(ch, ch[1])
             lines(x$vectors[, axes][ch, ],
-                  col = "black", lty = "dashed", ...)
+                  col = col[1L], lty = "dashed", ...)
+        }
+        if (ellipse) {
+                Ellipse(g$sites, type = ellipse.type,
+                        conf = conf, col = col[1L], lty = 1, lwd = 1)
         }
         points(g$centroids[1L], g$centroids[1L],
                pch = 16, cex = 1, col = "red", ...)

--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -8,11 +8,11 @@
     localBox <- function(..., col, bg, pch, cex, lty, lwd) box(...)
     localTitle <- function(..., col, bg, pch, cex, lty, lwd) title(...)
     Ellipse <- function(scrs, type, conf, col, lty, lwd) {
-        mat <- cov.wt(scrs, wt = rep_len(1, nrow(scrs)))
+        mat <- cov.wt(scrs)
         if (mat$n.obs == 1)
             mat$cov[] <- 0
         if (type == "se") {
-            mat$cov <- mat$cov * sum(mat$wt^2)
+            mat$cov <- mat$cov / mat$n.obs
         }
         xy <- if (mat$n.obs > 1) {
                   veganCovEllipse(mat$cov, mat$center, conf)

--- a/man/betadisper.Rd
+++ b/man/betadisper.Rd
@@ -38,6 +38,8 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE)
 
 \method{plot}{betadisper}(x, axes = c(1,2), cex = 0.7,
      pch = seq_len(ng), col = NULL, hull = TRUE,
+     ellipse = FALSE, ellipse.type = c("sd", "se"),
+     ellipse.conf = NULL,
      ylab, xlab, main, sub, \dots)
 
 \method{boxplot}{betadisper}(x, ylab = "Distance to centroid", ...)
@@ -63,6 +65,15 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE)
     call to \code{betadisper}.}
   \item{choices, axes}{the principal coordinate axes wanted.}
   \item{hull}{logical; should the convex hull for each group be plotted?}
+  \item{ellipse}{logical; should the confidence ellipse for each group
+    be plotted?}
+  \item{ellipse.type}{Whether standard deviations of points
+    (\code{"sd"}) or standard deviations of their averages (\code{"se"})
+    are used.}
+  \item{ellipse.conf}{Confidence limit for ellipses, e.g. 0.95. If
+    given, the corresponding \code{sd} or \code{se} is multiplied with
+    the corresponding value found from the Chi-squared distribution with
+    2df.}
   \item{pch}{plot symbols for the groups, a vector of length equal to the number of groups}
   \item{col}{colors for the plot symbols for the groups, a vector of length equal to the number of groups}
   \item{cex, ylab, xlab, main, sub}{graphical parameters. For details,
@@ -249,6 +260,9 @@ plot(mod.HSD)
 ## Plot the groups and distances to centroids on the
 ## first two PCoA axes
 plot(mod)
+
+## with confidence ellipses instead of hulls
+plot(mod, ellipse = TRUE, hull = FALSE, ellipse.type = "sd")
 
 ## can also specify which axes to plot, ordering respected
 plot(mod, axes = c(3,1))

--- a/tests/Examples/vegan-Ex.Rout.save
+++ b/tests/Examples/vegan-Ex.Rout.save
@@ -1,5 +1,5 @@
 
-R Under development (unstable) (2016-04-04 r70420) -- "Unsuffered Consequences"
+R version 3.2.4 Patched (2016-03-16 r70339) -- "Very Secure Dishes"
 Copyright (C) 2016 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 
@@ -1169,6 +1169,9 @@ ungrazed-grazed -0.1219422 -0.2396552 -0.004229243 0.0429502
 > ## Plot the groups and distances to centroids on the
 > ## first two PCoA axes
 > plot(mod)
+> 
+> ## with confidence ellipses instead of hulls
+> plot(mod, ellipse = TRUE, hull = FALSE, ellipse.type = "sd")
 > 
 > ## can also specify which axes to plot, ordering respected
 > plot(mod, axes = c(3,1))
@@ -8767,7 +8770,7 @@ Procrustes sum of squares:
 > ###
 > options(digits = 7L)
 > base::cat("Time elapsed: ", proc.time() - base::get("ptime", pos = 'CheckExEnv'),"\n")
-Time elapsed:  22.372 0.1 22.526 0 0 
+Time elapsed:  98.824 0.164 98.995 0 0 
 > grDevices::dev.off()
 null device 
           1 


### PR DESCRIPTION
As per feature request of #166 I implemented a first pass at this based on code from `ordiellipse()`. This is much simpler though as I only needed the code to draw ellipses as lines, not polygons and `plot.betadisper` draws these things in a loop, group by group, which further simplifies the code.

I'm not quite convinced I have this correct; needs to use `cov.wt()` as per `ordiellipse()` but I don't have `weights` for the PCoA used in `betadisper()` so I just set this to a vector of `1`s, again following `ordiellipse()`.

@jarioksa would you mind taking a look at this?