### PR TITLE
Exposing method argument in adipart/multipart/hiersimu

### DIFF
--- a/R/adipart.default.R
+++ b/R/adipart.default.R
@@ -1,11 +1,12 @@
 adipart.default <-
 function(y, x, index=c("richness", "shannon", "simpson"),
-    weights=c("unif", "prop"), relative = FALSE, nsimul=99, ...)
+    weights=c("unif", "prop"), relative = FALSE, nsimul=99,
+    method = "r2dtable", ...)
 {
     ## evaluate formula
     lhs <- as.matrix(y)
     if (missing(x))
-        x <- cbind(level_1=seq_len(nrow(lhs)), 
+        x <- cbind(level_1=seq_len(nrow(lhs)),
             leve_2=rep(1, nrow(lhs)))
     rhs <- data.frame(x)
     rhs[] <- lapply(rhs, as.factor)
@@ -45,9 +46,7 @@ function(y, x, index=c("richness", "shannon", "simpson"),
         ftmp[[i]] <- as.formula(paste("~", tlab[i], "- 1"))
     }
 
-    ## is there a method/burnin/thin in ... ?
-    method <- if (is.null(list(...)$method))
-        "r2dtable" else list(...)$method
+    ## is there burnin/thin in ... ?
     burnin <- if (is.null(list(...)$burnin))
         0 else list(...)$burnin
     thin <- if (is.null(list(...)$thin))

--- a/R/adipart.formula.R
+++ b/R/adipart.formula.R
@@ -1,17 +1,16 @@
 `adipart.formula` <-
     function(formula, data, index=c("richness", "shannon", "simpson"),
-             weights=c("unif", "prop"), relative = FALSE, nsimul=99, ...)
+             weights=c("unif", "prop"), relative = FALSE, nsimul=99,
+             method = "r2dtable", ...)
 {
     ## evaluate formula
     if (missing(data))
         data <- parent.frame()
     tmp <- hierParseFormula(formula, data)
-    lhs <- tmp$lhs
-    rhs <- tmp$rhs
-
     ## run simulations
-    sim <- adipart.default(lhs, rhs, index = index, weights = weights,
-                           relative = relative, nsimul = nsimul, ...)
+    sim <- adipart.default(tmp$lhs, tmp$rhs, index = index, weights = weights,
+                           relative = relative, nsimul = nsimul,
+                           method = method, ...)
     call <- match.call()
     call[[1]] <- as.name("adipart")
     attr(sim, "call") <- call

--- a/R/hiersimu.default.R
+++ b/R/hiersimu.default.R
@@ -1,11 +1,12 @@
 hiersimu.default <-
 function(y, x, FUN, location = c("mean", "median"),
-relative = FALSE, drop.highest = FALSE, nsimul=99, ...)
+         relative = FALSE, drop.highest = FALSE, nsimul=99,
+         method = "r2dtable", ...)
 {
     ## evaluate formula
     lhs <- as.matrix(y)
     if (missing(x))
-        x <- cbind(level_1=seq_len(nrow(lhs)), 
+        x <- cbind(level_1=seq_len(nrow(lhs)),
             leve_2=rep(1, nrow(lhs)))
     rhs <- data.frame(x)
     rhs[] <- lapply(rhs, as.factor)
@@ -46,9 +47,7 @@ relative = FALSE, drop.highest = FALSE, nsimul=99, ...)
         ftmp[[i]] <- as.formula(paste("~", tlab[i], "- 1"))
     }
 
-    ## is there a method/burnin/thin in ... ?
-    method <- if (is.null(list(...)$method))
-        "r2dtable" else list(...)$method
+    ## is there burnin/thin in ... ?
     burnin <- if (is.null(list(...)$burnin))
         0 else list(...)$burnin
     thin <- if (is.null(list(...)$thin))

--- a/R/hiersimu.formula.R
+++ b/R/hiersimu.formula.R
@@ -1,18 +1,16 @@
 `hiersimu.formula` <-
     function(formula, data, FUN, location = c("mean", "median"),
-             relative = FALSE, drop.highest = FALSE, nsimul=99, ...)
+             relative = FALSE, drop.highest = FALSE, nsimul=99,
+             method = "r2dtable", ...)
 {
     ## evaluate formula
     if (missing(data))
         data <- parent.frame()
     tmp <- hierParseFormula(formula, data)
-    lhs <- tmp$lhs
-    rhs <- tmp$rhs
-
     ## run simulations
-    sim <- hiersimu.default(lhs, rhs, FUN = FUN, location = location,
+    sim <- hiersimu.default(tmp$lhs, tmp$rhs, FUN = FUN, location = location,
                             relative = relative, drop.highest = drop.highest,
-                            nsimul = nsimul, ...)
+                            nsimul = nsimul, method = method, ...)
     call <- match.call()
     call[[1]] <- as.name("hiersimu")
     attr(sim, "call") <- call

--- a/R/multipart.default.R
+++ b/R/multipart.default.R
@@ -1,6 +1,7 @@
 `multipart.default` <-
     function(y, x, index=c("renyi", "tsallis"), scales = 1,
-             global = FALSE, relative = FALSE, nsimul=99, ...)
+             global = FALSE, relative = FALSE, nsimul=99,
+             method = "r2dtable", ...)
 {
     if (length(scales) > 1)
         stop("length of 'scales' must be 1")
@@ -49,9 +50,7 @@
         ftmp[[i]] <- as.formula(paste("~", tlab[i], "- 1"))
     }
 
-    ## is there a method/burnin/thin in ... ?
-    method <- if (is.null(list(...)$method))
-        "r2dtable" else list(...)$method
+    ## is there burnin/thin in ... ?
     burnin <- if (is.null(list(...)$burnin))
         0 else list(...)$burnin
     thin <- if (is.null(list(...)$thin))

--- a/R/multipart.formula.R
+++ b/R/multipart.formula.R
@@ -1,18 +1,16 @@
 `multipart.formula` <-
     function(formula, data, index=c("renyi", "tsallis"), scales = 1,
-             global = FALSE, relative = FALSE, nsimul=99, ...)
+             global = FALSE, relative = FALSE, nsimul=99,
+             method = "r2dtable", ...)
 {
     ## evaluate formula
     if (missing(data))
         data <- parent.frame()
     tmp <- hierParseFormula(formula, data)
-    lhs <- tmp$lhs
-    rhs <- tmp$rhs
-
     ## run simulations
-    sim <- multipart.default(lhs, rhs, index = index, scales = scales,
+    sim <- multipart.default(tmp$lhs, tmp$rhs, index = index, scales = scales,
                              global = global, relative = relative,
-                             nsimul = nsimul, ...)
+                             nsimul = nsimul, method = method, ...)
     call <- match.call()
     call[[1]] <- as.name("multipart")
     attr(sim, "call") <- call

--- a/man/adipart.Rd
+++ b/man/adipart.Rd
@@ -9,23 +9,27 @@
 
 \title{Additive Diversity Partitioning and Hierarchical Null Model Testing}
 \description{
-In additive diversity partitioning, mean values of alpha diversity at lower levels of a sampling 
-hierarchy are compared to the total diversity in the entire data set (gamma diversity). 
-In hierarchical null model testing, a statistic returned by a function is evaluated 
+In additive diversity partitioning, mean values of alpha diversity at lower levels of a sampling
+hierarchy are compared to the total diversity in the entire data set (gamma diversity).
+In hierarchical null model testing, a statistic returned by a function is evaluated
 according to a nested hierarchical sampling design (\code{hiersimu}).
 }
 \usage{
 adipart(...)
 \method{adipart}{default}(y, x, index=c("richness", "shannon", "simpson"),
-    weights=c("unif", "prop"), relative = FALSE, nsimul=99, ...)
+    weights=c("unif", "prop"), relative = FALSE, nsimul=99,
+    method = "r2dtable", ...)
 \method{adipart}{formula}(formula, data, index=c("richness", "shannon", "simpson"),
-    weights=c("unif", "prop"), relative = FALSE, nsimul=99, ...)
+    weights=c("unif", "prop"), relative = FALSE, nsimul=99,
+    method = "r2dtable", ...)
 
 hiersimu(...)
 \method{hiersimu}{default}(y, x, FUN, location = c("mean", "median"),
-    relative = FALSE, drop.highest = FALSE, nsimul=99, ...)
+    relative = FALSE, drop.highest = FALSE, nsimul=99,
+    method = "r2dtable", ...)
 \method{hiersimu}{formula}(formula, data, FUN, location = c("mean", "median"),
-    relative = FALSE, drop.highest = FALSE, nsimul=99, ...)
+    relative = FALSE, drop.highest = FALSE, nsimul=99,
+    method = "r2dtable", ...)
 }
 \arguments{
   \item{y}{A community matrix.}
@@ -57,10 +61,16 @@ hiersimu(...)
     values are given relative to the value of gamma for function
     \code{adipart}.}
 
-  \item{nsimul}{Number of permutations to use if \code{matr} is not of
-    class 'permat'.  If \code{nsimul = 0}, only the \code{FUN} argument
-    is evaluated. It is thus possible to reuse the statistic values
-    without using a null model.}
+  \item{nsimul}{Number of permutations to use.  If \code{nsimul = 0},
+    only the \code{FUN} argument is evaluated.
+    It is thus possible to reuse the statistic values
+    without a null model.}
+
+  \item{method}{Null model method: either a name (character string) of
+    a method defined in \code{\link{make.commsim}} or a
+    \code{\link{commsim}} function.
+    The default \code{"r2dtable"} keeps row sums and column sums fixed.
+    See \code{\link{oecosimu}} for Details and Examples.}
 
   \item{FUN}{A function to be used by \code{hiersimu}. This must be
     fully specified, because currently other arguments cannot be passed

--- a/man/multipart.Rd
+++ b/man/multipart.Rd
@@ -6,73 +6,98 @@
 \title{Multiplicative Diversity Partitioning}
 
 \description{
-In multiplicative diversity partitioning, mean values of alpha diversity at lower levels of a sampling 
-hierarchy are compared to the total diversity in the entire data set or the pooled samples (gamma diversity). 
+In multiplicative diversity partitioning, mean values of alpha diversity at lower levels of a sampling
+hierarchy are compared to the total diversity in the entire data set or the pooled samples (gamma diversity).
 }
 \usage{
 multipart(...)
 \method{multipart}{default}(y, x, index=c("renyi", "tsallis"), scales = 1,
-    global = FALSE, relative = FALSE, nsimul=99, ...)
+    global = FALSE, relative = FALSE, nsimul=99, method = "r2dtable", ...)
 \method{multipart}{formula}(formula, data, index=c("renyi", "tsallis"), scales = 1,
-    global = FALSE, relative = FALSE, nsimul=99, ...)
+    global = FALSE, relative = FALSE, nsimul=99, method = "r2dtable", ...)
 }
 \arguments{
   \item{y}{A community matrix.}
+
   \item{x}{A matrix with same number of rows as in \code{y}, columns
     coding the levels of sampling hierarchy. The number of groups within
     the hierarchy must decrease from left to right. If \code{x} is missing,
     two levels are assumed: each row is a group in the first level, and
     all rows are in the same group in the second level.}
-  \item{formula}{A two sided model formula in the form \code{y ~ x}, where \code{y} 
-    is the community data matrix with samples as rows and species as column. Right 
-    hand side (\code{x}) must be grouping variables referring to levels of sampling hierarchy, 
-    terms from right to left will be treated as nested (first column is the lowest, 
-    last is the highest level, at least two levels specified). Interaction terms are not allowed.}
-  \item{data}{A data frame where to look for variables defined in the right hand side 
-    of \code{formula}. If missing, variables are looked in the global environment.}
+
+  \item{formula}{A two sided model formula in the form \code{y ~ x},
+    where \code{y} is the community data matrix with samples as rows and
+    species as column. Right hand side (\code{x}) must be grouping variables
+    referring to levels of sampling hierarchy, terms from right to left will
+    be treated as nested (first column is the lowest,
+    last is the highest level, at least two levels specified).
+    Interaction terms are not allowed.}
+
+  \item{data}{A data frame where to look for variables defined in the
+    right hand side of \code{formula}. If missing, variables are looked
+    in the global environment.}
+
   \item{index}{Character, the entropy index to be calculated (see Details).}
+
   \item{relative}{Logical, if \code{TRUE} then beta diversity is
     standardized by its maximum (see Details).}
-  \item{scales}{Numeric, of length 1, the order of the generalized diversity index 
-    to be used.}
-  \item{global}{Logical, indicates the calculation of beta diversity values, see Details.}
-  \item{nsimul}{Number of permutation to use if \code{matr} is not of class 'permat'.
-    If \code{nsimul = 0}, only the \code{FUN} argument is evaluated. It is thus possible
-    to reuse the statistic values without using a null model.}
-  \item{\dots}{Other arguments passed to \code{\link{oecosimu}}, i.e. 
+
+  \item{scales}{Numeric, of length 1, the order of the generalized
+    diversity index to be used.}
+
+  \item{global}{Logical, indicates the calculation of beta diversity values,
+    see Details.}
+
+  \item{nsimul}{Number of permutations to use.  If \code{nsimul = 0},
+    only the \code{FUN} argument is evaluated.
+    It is thus possible to reuse the statistic values
+    without a null model.}
+
+  \item{method}{Null model method: either a name (character string) of
+    a method defined in \code{\link{make.commsim}} or a
+    \code{\link{commsim}} function.
+    The default \code{"r2dtable"} keeps row sums and column sums fixed.
+    See \code{\link{oecosimu}} for Details and Examples.}
+
+  \item{\dots}{Other arguments passed to \code{\link{oecosimu}}, i.e.
     \code{method}, \code{thin} or \code{burnin}.}
 }
 \details{
-Multiplicative diversity partitioning is based on Whittaker's (1972) ideas, that has 
-recently been generalised to one parametric diversity families (i.e. \enc{Rényi}{Renyi} 
-and Tsallis) by Jost (2006, 2007). Jost recommends to use the numbers equivalents 
-(Hill numbers), instead of pure diversities, and proofs, that this satisfies the 
+Multiplicative diversity partitioning is based on Whittaker's (1972) ideas,
+that has recently been generalised to one parametric diversity families
+(i.e. \enc{Rényi}{Renyi} and Tsallis) by Jost (2006, 2007).
+Jost recommends to use the numbers equivalents (Hill numbers),
+instead of pure diversities, and proofs, that this satisfies the
 multiplicative partitioning requirements.
 
-The current implementation of \code{multipart} calculates Hill numbers based on the 
-functions \code{\link{renyi}} and \code{\link{tsallis}} (provided as \code{index} argument). 
-If values for more than one \code{scales} are desired, it should be done in separate 
-runs, because it adds extra dimensionality to the implementation, which has not been resolved 
-efficiently.
+The current implementation of \code{multipart} calculates Hill numbers
+based on the functions \code{\link{renyi}} and \code{\link{tsallis}}
+(provided as \code{index} argument).
+If values for more than one \code{scales} are desired,
+it should be done in separate runs, because it adds extra dimensionality
+to the implementation, which has not been resolved efficiently.
 
-Alpha diversities are then the averages of these Hill numbers for each hierarchy levels, 
-the global gamma diversity is the alpha value calculated for the highest hierarchy level. 
+Alpha diversities are then the averages of these Hill numbers for
+each hierarchy levels, the global gamma diversity is the alpha value
+calculated for the highest hierarchy level.
 When \code{global = TRUE}, beta is calculated relative to the global gamma value:
 \deqn{\beta_i = \gamma / \alpha_{i}}{beta_i = gamma / alpha_i}
-when \code{global = FALSE}, beta is calculated relative to local gamma values (local gamma
-means the diversity calculated for a particular cluster based on the pooled abundance vector):
+when \code{global = FALSE}, beta is calculated relative to local
+gamma values (local gamma means the diversity calculated for a particular
+cluster based on the pooled abundance vector):
 \deqn{\beta_ij = \alpha_{(i+1)j} / mean(\alpha_{ij})}{beta_ij = alpha_(i+1)j / mean(alpha_i)}
-where \eqn{j} is a particular cluster at hierarchy level \eqn{i}. Then beta diversity value for
-level \eqn{i} is the mean of the beta values of the clusters at that level,
-\eqn{\beta_{i} = mean(\beta_{ij})}.
+where \eqn{j} is a particular cluster at hierarchy level \eqn{i}.
+Then beta diversity value for level \eqn{i} is the mean of the beta
+values of the clusters at that level, \eqn{\beta_{i} = mean(\beta_{ij})}.
 
 If \code{relative = TRUE}, the respective beta diversity values are
 standardized by their maximum possible values (\eqn{mean(\beta_{ij}) / \beta_{max,ij}})
-given as \eqn{\beta_{max,ij} = n_{j}} (the number of lower level units in a given cluster \eqn{j}).
+given as \eqn{\beta_{max,ij} = n_{j}} (the number of lower level units
+in a given cluster \eqn{j}).
 
-The expected diversity components are calculated \code{nsimul} times by individual based 
-randomisation of the community data matrix. This is done by the \code{"r2dtable"} method
-in \code{\link{oecosimu}} by default.
+The expected diversity components are calculated \code{nsimul}
+times by individual based randomization of the community data matrix.
+This is done by the \code{"r2dtable"} method in \code{\link{oecosimu}} by default.
 }
 \value{
 An object of class 'multipart' with same structure as 'oecosimu' objects.


### PR DESCRIPTION
@jarioksa suggested to expose `method` argument passed to `oecosimu` in the functions `adipart`, `multipart`, and `hiersimu`

> I think it could be useful to expose the null model argument in adipart and hiersimu. 
> You can pass it as method, but it seems that the user knows the vegan design very well to realize 
> that this is the way to pass null model. In raupcrick() I do have explicit passing just to make 
> users aware of this possibility.