### PR TITLE
Biplot scaling in cca/rda/capscale/dbrda

### DIFF
--- a/R/scores.cca.R
+++ b/R/scores.cca.R
@@ -70,6 +70,11 @@
             rnk]]
         colnames(b) <- c(colnames(x$CCA$u), colnames(x$CA$u))[choices]
         rownames(b) <- rownames(x$CCA$biplot)
+        if (scaling) {
+            scal <- list(slam, 1, sqrt(slam))[[abs(scaling)]]
+            scal <- scal/max(scal) # scale proportionally to the "best" dim
+            b <- sweep(b, 2, scal, "*")
+        }
         sol$biplot <- b
     }
     if ("centroids" %in% take) {

--- a/R/scores.rda.R
+++ b/R/scores.rda.R
@@ -89,6 +89,10 @@
         b[, choices <= rnk] <- x$CCA$biplot[, choices[choices <= rnk]]
         colnames(b) <- c(colnames(x$CCA$u), colnames(x$CA$u))[choices]
         rownames(b) <- rownames(x$CCA$biplot)
+        if (scaling) {
+            scal <- list(slam, 1, sqrt(slam))[[abs(scaling)]]
+            b <- sweep(b, 2, scal, "*")
+        }
         sol$biplot <- b
     }
     if ("centroids" %in% take) {

--- a/R/scores.rda.R
+++ b/R/scores.rda.R
@@ -91,6 +91,7 @@
         rownames(b) <- rownames(x$CCA$biplot)
         if (scaling) {
             scal <- list(slam, 1, sqrt(slam))[[abs(scaling)]]
+            scal <- scal/max(scal) # scale proportionally to the "best" dim
             b <- sweep(b, 2, scal, "*")
         }
         sol$biplot <- b

--- a/man/plot.cca.Rd
+++ b/man/plot.cca.Rd
@@ -116,15 +116,18 @@
 
   Environmental variables receive a special treatment. With
   \code{display="bp"}, arrows will be drawn. These are labelled with
-  \code{text} and unlabelled with \code{points}. The basic \code{plot}
-  function uses a simple (but not very clever) heuristics for adjusting
-  arrow lengths to plots, but the user can give the expansion factor in
-  \code{mul.arrow}. With \code{display="cn"} the centroids of levels of
-  \code{\link{factor}} variables are displayed (these are available only if there were
-  factors and a formula interface was used in \code{\link{cca}} or
-  \code{\link{rda}}). With this option continuous
-  variables still are presented as arrows and ordered factors as arrows
-  and centroids. 
+  \code{text} and unlabelled with \code{points}. The arrows have
+  basically unit scaling, but if sites were scaled (\code{scaling}
+  \code{"sites"} or \code{"symmetric"}), the scores of requested axes
+  are adjusted relative to the axis with highest eigenvalue. The basic
+  \code{plot} function uses a simple heuristics for adjusting the
+  unit-length arrows to the current plot area, but the user can give
+  the expansion factor in \code{mul.arrow}.  With \code{display="cn"}
+  the centroids of levels of \code{\link{factor}} variables are
+  displayed (these are available only if there were factors and a
+  formula interface was used in \code{\link{cca}} or
+  \code{\link{rda}}). With this option continuous variables still are
+  presented as arrows and ordered factors as arrows and centroids.
 
   If you want to have still a better control of plots, it is better to
   produce them using primitive \code{plot} commands. Function


### PR DESCRIPTION
Daniel Borcard wrote:

>  I have noticed something strange: the biplot scores for scaling 1 and 2 are identical. To my knowledge they should be different: the scaling 1 scores are supposed to be scaled by the square root of their (relative) eigenvalues (Legendre and Legendre 2012, eq. 11.20 p. 639).

This was actually a design decision, and the semi-official vegan-tutorial mentions the behaviour. However, this may be undesirable. The following code demonstrates the behaviour:

```R
library(vegan)
data(dune, dune.env)
m0 <- rda(dune ~ Management, dune.env)
x <- model.matrix(m0)
m <- rda(dune ~ x)
plot(m, dis=c("lc","bp"), scaling="species") # scores and arrow match
plot(m, dis=c("lc","bp"), scaling="sites")    # scores and arrows do not before this PR
```

It was not quite obvious how to implement this. Basically, the biplot scores give unit-length vectors, and that was the reason why they were left unscaled. After this PR the extracted scores no longer have unit lengths, but they are shorter. I decided to adjust the scores so that the scores on axis with the largest eigenvalue among the extracted axes are left as-is, and the others are downscaled like defined in the `scaling` argument. The actual scores used in `plot` will be different: `ordiArrowMul()` will stretch or shrink the scores to fill the current plotting area.