### PR TITLE
Issue #198: permutest(<dbrda-result>, first = TRUE) fails

### DIFF
--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -72,14 +72,13 @@ permutest.default <- function(x, ...)
                 Q <- qr(XY)
             }
             tmp <- qr.fitted(Q, Y)
-            if (isDB)
-                tmp <- qr.fitted(Q, t(tmp))
-            if (first)
-                if (isDB)
-                    cca.ev <- eigen(tmp)$values[1]
-                else
+            if (first) {
+                if (isDB) {
+                    tmp <- qr.fitted(Q, t(tmp)) # eigen needs symmetric tmp
+                    cca.ev <- eigen(tmp, symmetric = TRUE)$values[1]
+                } else
                     cca.ev <- La.svd(tmp, nv = 0, nu = 0)$d[1]^2
-            else
+            } else
                 cca.ev <- getEV(tmp, isDB)
             if (isPartial || first) {
                 tmp <- qr.resid(Q, Y)

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -57,6 +57,8 @@ permutest.default <- function(x, ...)
                     QZ <- qr(XZ)
                 }
                 Y <- qr.resid(QZ, Y)
+                if (isDB)
+                    Y <- qr.resid(QZ, t(Y))
             }
             if (isCCA) {
                 XY <- .C("wcentre", x = as.double(X), as.double(wtake),

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -24,6 +24,10 @@ permutest.default <- function(x, ...)
     ## special cases
     isCCA <- !inherits(x, "rda")    # weighting
     isPartial <- !is.null(x$pCCA)   # handle conditions
+    ## first eigenvalue cannot be analysed with capscale which had
+    ## discarded imaginary values: cast to old before evaluating isDB
+    if (first && inherits(x, "capscale"))
+        x <- oldCapscale(x)
     isDB <- inherits(x, c("capscale", "dbrda")) &&
         !inherits(x, "oldcapscale")  # distance-based & new design
     ## Function to get the F statistics in one loop
@@ -87,6 +91,7 @@ permutest.default <- function(x, ...)
         mat
     }
     ## end getF()
+
     if (first) {
         Chi.z <- x$CCA$eig[1]
         q <- 1

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -66,6 +66,8 @@ permutest.default <- function(x, ...)
                 Q <- qr(XY)
             }
             tmp <- qr.fitted(Q, Y)
+            if (isDB)
+                tmp <- qr.fitted(Q, t(tmp))
             if (first)
                 if (isDB)
                     cca.ev <- eigen(tmp)$values[1]


### PR DESCRIPTION
This PR fixes following problems:

* `permutest(<dbrda-result>, first = TRUE)` fails as reported in issue #198. The comments to issue #198 explain the reasons and fix in more detail. Commits 0f4cf0c2bec and 346ea39a72
* `capscale` uses only real dimensions in finding the eigenvalues, and `first=TRUE` cannot be analysed similarly as with `dbrda`. Commit daa34e6f6da
* Profiling showed that a large part of time was spent in `eigen` when it tried to find out if the input matrix was symmetric. Now the input is guaranteed to be symmetric, and telling this to `eigen` can make the function to run almost 2x faster. Commit c76a1bebffe