### PR TITLE
data as matrix errors

### DIFF
--- a/R/adonis2.R
+++ b/R/adonis2.R
@@ -55,7 +55,8 @@
     if (missing(data))
         data <- .GlobalEnv
     else
-        data <- ordiGetData(match.call(), environment(formula))
+        data <- eval(match.call()$data, environment(formula),
+                     enclos = .GlobalEnv)
     ## First we collect info for the uppermost level of the analysed
     ## object
     Trms <- terms(delete.response(formula), data = data)
@@ -87,7 +88,7 @@
     Gfit <- qr.fitted(qrhs, G)
     Gres <- qr.resid(qrhs, G)
     ## collect data for the fit
-    if(!is.null(qrhs$rank) && qrhs$rank > 0) 
+    if(!is.null(qrhs$rank) && qrhs$rank > 0)
         CCA <- list(rank = qrhs$rank,
                     qrank = qrhs$rank,
                     tot.chi = sum(diag(Gfit)),

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -1,16 +1,17 @@
 `capscale` <-
     function (formula, data, distance = "euclidean", sqrt.dist = FALSE,
               comm = NULL, add = FALSE, dfun = vegdist,
-              metaMDSdist = FALSE, na.action = na.fail, subset = NULL, ...) 
+              metaMDSdist = FALSE, na.action = na.fail, subset = NULL, ...)
 {
     EPS <- sqrt(.Machine$double.eps)
-    if (!inherits(formula, "formula")) 
+    if (!inherits(formula, "formula"))
         stop("Needs a model formula")
     if (missing(data)) {
         data <- parent.frame()
     }
     else {
-        data <- ordiGetData(match.call(), environment(formula))
+        data <- eval(match.call()$data, environment(formula),
+                     enclos = .GlobalEnv)
     }
     formula <- formula(terms(formula, data = data))
     ## The following line was eval'ed in environment(formula), but
@@ -74,7 +75,7 @@
     else {
         adjust <- sqrt(k)
     }
-    nm <- attr(X, "Labels")    
+    nm <- attr(X, "Labels")
     ## wcmdscale, optionally with additive adjustment
     X <- wcmdscale(X, x.ret = TRUE, add = add)
     ## this may have been euclidified: update inertia
@@ -82,7 +83,7 @@
         inertia <- paste(paste0(toupper(substring(X$add, 1, 1)),
                                 substring(X$add, 2)),
                          "adjusted", inertia)
-    if (is.null(rownames(X$points))) 
+    if (is.null(rownames(X$points)))
         rownames(X$points) <- nm
     X$points <- adjust * X$points
     ## We adjust eigenvalues to variances, and simultaneously the
@@ -152,7 +153,7 @@
         ## NA action after 'subset'
         if (!is.null(d$na.action))
             comm <- comm[-d$na.action, , drop = FALSE]
-        if (!is.null(sol$pCCA) && sol$pCCA$rank > 0) 
+        if (!is.null(sol$pCCA) && sol$pCCA$rank > 0)
             comm <- qr.resid(sol$pCCA$QR, comm)
         if (!is.null(sol$CCA) && sol$CCA$rank > 0) {
             v.eig <- t(comm) %*% sol$CCA$u/sqrt(k)
@@ -171,13 +172,13 @@
             sol$CCA$v[] <- NA
         sol$colsum <- NA
     }
-    if (!is.null(sol$CCA) && sol$CCA$rank > 0) 
+    if (!is.null(sol$CCA) && sol$CCA$rank > 0)
         sol$CCA$centroids <- centroids.cca(sol$CCA$wa, d$modelframe)
-    if (!is.null(sol$CCA$alias)) 
+    if (!is.null(sol$CCA$alias))
         sol$CCA$centroids <- unique(sol$CCA$centroids)
     if (!is.null(sol$CCA$centroids)) {
         rs <- rowSums(sol$CCA$centroids^2)
-        sol$CCA$centroids <- sol$CCA$centroids[rs > 1e-04, , 
+        sol$CCA$centroids <- sol$CCA$centroids[rs > 1e-04, ,
                                                drop = FALSE]
         if (nrow(sol$CCA$centroids) == 0)
             sol$CCA$centroids <- NULL

--- a/R/capscale.R
+++ b/R/capscale.R
@@ -52,7 +52,8 @@
     d <- ordiParseFormula(formula,
                           data,
                           na.action = na.action,
-                          subset = substitute(subset))
+                          subset = substitute(subset),
+                          X = X)
     ## ordiParseFormula subsets rows of dissimilarities: do the same
     ## for columns ('comm' is handled later). ordiParseFormula
     ## returned the original data, but we use instead the potentially

--- a/R/cca.formula.R
+++ b/R/cca.formula.R
@@ -4,7 +4,8 @@
     if (missing(data)) {
         data <- parent.frame()
     } else {
-        data <- ordiGetData(match.call(), environment(formula))
+        data <- eval(data, environment(formula),
+                     enclos = .GlobalEnv)
     }
     d <- ordiParseFormula(formula, data, na.action = na.action,
                           subset = substitute(subset))

--- a/R/cca.formula.R
+++ b/R/cca.formula.R
@@ -4,10 +4,10 @@
     if (missing(data)) {
         data <- parent.frame()
     } else {
-        data <- eval(data, environment(formula),
+        data <- eval(match.call()$data, environment(formula),
                      enclos = .GlobalEnv)
     }
-    d <- ordiParseFormula(formula, data, na.action = na.action,
+    d <- ordiParseFormula(formula, data = data, na.action = na.action,
                           subset = substitute(subset))
     sol <- cca.default(d$X, d$Y, d$Z)
     if (!is.null(sol$CCA) && sol$CCA$rank > 0) 

--- a/R/dbrda.R
+++ b/R/dbrda.R
@@ -2,16 +2,17 @@
     function (formula, data, distance = "euclidean",
               sqrt.dist = FALSE,  add = FALSE, dfun = vegdist,
               metaMDSdist = FALSE, na.action = na.fail,
-              subset = NULL, ...) 
+              subset = NULL, ...)
 {
     EPS <- sqrt(.Machine$double.eps)
-    if (!inherits(formula, "formula")) 
+    if (!inherits(formula, "formula"))
         stop("Needs a model formula")
     if (missing(data)) {
         data <- parent.frame()
     }
     else {
-        data <- ordiGetData(match.call(), environment(formula))
+        data <- eval(match.call()$data, environment(formula),
+                     enclos = .GlobalEnv)
     }
     formula <- formula(terms(formula, data = data))
     ## The following line was eval'ed in environment(formula), but
@@ -94,7 +95,7 @@
     else {
         adjust <- sqrt(k)
     }
-    nm <- attr(X, "Labels")    
+    nm <- attr(X, "Labels")
     ## Get components of inertia with negative eigenvalues following
     ## McArdle & Anderson (2001), section "Theory". G is their
     ## double-centred Gower matrix, but instead of hat matrix, we use
@@ -118,7 +119,7 @@
     }
     ## CCA
     if (!is.null(d$Y)) {
-        d$Y <- scale(d$Y, scale = FALSE) 
+        d$Y <- scale(d$Y, scale = FALSE)
         Q <- qr(cbind(d$Z, d$Y), tol = 1e-6)
         HGH <- qr.fitted(Q, t(qr.fitted(Q, G)))
         e <- eigen(HGH, symmetric = TRUE)
@@ -216,14 +217,14 @@
     }
 
     sol$colsum <- NA
-    if (!is.null(sol$CCA) && sol$CCA$rank > 0) 
+    if (!is.null(sol$CCA) && sol$CCA$rank > 0)
         sol$CCA$centroids <-
             centroids.cca(sol$CCA$u, d$modelframe)
-    if (!is.null(sol$CCA$alias)) 
+    if (!is.null(sol$CCA$alias))
         sol$CCA$centroids <- unique(sol$CCA$centroids)
     if (!is.null(sol$CCA$centroids)) {
         rs <- rowSums(sol$CCA$centroids^2)
-        sol$CCA$centroids <- sol$CCA$centroids[rs > 1e-04, , 
+        sol$CCA$centroids <- sol$CCA$centroids[rs > 1e-04, ,
                                                drop = FALSE]
         if (nrow(sol$CCA$centroids) == 0)
             sol$CCA$centroids <- NULL

--- a/R/dbrda.R
+++ b/R/dbrda.R
@@ -50,7 +50,8 @@
     d <- ordiParseFormula(formula,
                           data,
                           na.action = na.action,
-                          subset = substitute(subset))
+                          subset = substitute(subset),
+                          X = X)
     ## ordiParseFormula subsets rows of dissimilarities: do the same
     ## for columns ('comm' is handled later). ordiParseFormula
     ## returned the original data, but we use instead the potentially

--- a/R/ordiGetData.R
+++ b/R/ordiGetData.R
@@ -1,5 +1,0 @@
-`ordiGetData` <-
-function (call, env)
-{
-    eval(call$data, env, enclos = .GlobalEnv)
-}

--- a/R/ordiGetData.R
+++ b/R/ordiGetData.R
@@ -1,10 +1,5 @@
 `ordiGetData` <-
-function (call, env) 
+function (call, env)
 {
-    call$scale <- call$distance <- call$comm <- call$add <- call$method <- 
-        call$dfun <- call$sqrt.dist <- call$metaMDSdist <- call$subset <- NULL
-    call$na.action <- na.pass
-    call[[2]] <- NULL
-    call[[1]] <- as.name("model.frame")
-    eval(call, env, enclos = .GlobalEnv)
+    eval(call$data, env, enclos = .GlobalEnv)
 }

--- a/R/rda.formula.R
+++ b/R/rda.formula.R
@@ -1,22 +1,23 @@
 `rda.formula` <-
     function (formula, data, scale = FALSE, na.action = na.fail,
-              subset = NULL, ...) 
+              subset = NULL, ...)
 {
     if (missing(data)) {
         data <- parent.frame()
     } else {
-        data <- ordiGetData(match.call(), environment(formula))
+        data <- eval(match.call()$data, environment(formula),
+                     enclos = .GlobalEnv)
     }
-    d <- ordiParseFormula(formula, data, na.action = na.action,
+    d <- ordiParseFormula(formula, data = data, na.action = na.action,
                           subset = substitute(subset))
     sol <- rda.default(d$X, d$Y, d$Z, scale)
-    if (!is.null(sol$CCA) && sol$CCA$rank > 0) 
+    if (!is.null(sol$CCA) && sol$CCA$rank > 0)
         sol$CCA$centroids <- centroids.cca(sol$CCA$wa, d$modelframe)
-    if (!is.null(sol$CCA$alias)) 
+    if (!is.null(sol$CCA$alias))
         sol$CCA$centroids <- unique(sol$CCA$centroids)
     if (!is.null(sol$CCA$centroids)) {
         rs <- rowSums(sol$CCA$centroids^2)
-        sol$CCA$centroids <- sol$CCA$centroids[rs > 1e-04, , 
+        sol$CCA$centroids <- sol$CCA$centroids[rs > 1e-04, ,
             drop = FALSE]
         if (length(sol$CCA$centroids) == 0)
             sol$CCA$centroids <- NULL

--- a/man/vegan-internal.Rd
+++ b/man/vegan-internal.Rd
@@ -1,5 +1,4 @@
 \name{vegan-internal}
-\alias{ordiGetData}
 \alias{ordiParseFormula}
 \alias{ordiNAexclude}
 \alias{ordiNApredict}
@@ -23,7 +22,6 @@
   but only within other functions.
 }
 \usage{
-ordiGetData(call, env)
 ordiParseFormula(formula, data, xlev = NULL,  na.action = na.fail,
     subset = NULL)
 ordiTerminfo(d, data)
@@ -50,9 +48,7 @@ addCailliez(d)
   \code{\link{get}} or \code{\link{:::}} to directly call these
   functions.
   
-  \code{ordiGetData} finds the model frame of constraints and
-  conditions in constrained ordination in the defined
-  \code{env}ironment.  \code{ordiParseFormula} returns a list of three
+  \code{ordiParseFormula} returns a list of three
   matrices (dependent variables, and \code{\link{model.matrix}} of
   constraints and conditions, possibly \code{NULL}) needed in
   constrained ordination. Argument \code{xlev} is passed to

--- a/man/vegan-internal.Rd
+++ b/man/vegan-internal.Rd
@@ -23,7 +23,7 @@
 }
 \usage{
 ordiParseFormula(formula, data, xlev = NULL,  na.action = na.fail,
-    subset = NULL)
+    subset = NULL, X)
 ordiTerminfo(d, data)
 ordiNAexclude(x, excluded)
 ordiNApredict(omit, x)
@@ -48,18 +48,20 @@ addCailliez(d)
   \code{\link{get}} or \code{\link{:::}} to directly call these
   functions.
   
-  \code{ordiParseFormula} returns a list of three
-  matrices (dependent variables, and \code{\link{model.matrix}} of
-  constraints and conditions, possibly \code{NULL}) needed in
-  constrained ordination. Argument \code{xlev} is passed to
-  \code{\link{model.frame}}. \code{ordiTermInfo} finds the term
+  \code{ordiParseFormula} returns a list of three matrices (dependent
+  variables, and \code{\link{model.matrix}} of constraints and
+  conditions, possibly \code{NULL}) needed in constrained
+  ordination. Argument \code{xlev} is passed to
+  \code{\link{model.frame}}. If the left-hand-side was already
+  evaluated in calling code, it can be given as argument \code{X} and
+  will not be re-evaluated. \code{ordiTermInfo} finds the term
   information for constrained ordination as described in
   \code{\link{cca.object}}. \code{ordiNAexclude} implements
   \code{na.action = na.exclude} for constrained ordination finding WA
   scores of CCA components and site scores of unconstrained component
   from \code{excluded} rows of observations. Function
-  \code{ordiNApredict} pads the result object with these or with
-  WA scores similarly as \code{\link{napredict}}.
+  \code{ordiNApredict} pads the result object with these or with WA
+  scores similarly as \code{\link{napredict}}.
 
   \code{ordiArgAbsorber} absorbs arguments of \code{\link{scores}}
   function of \pkg{vegan} so that these do not cause superfluous


### PR DESCRIPTION
This PR simplifies formula manipulations in constrained ordination. It started as a response to issue #200, and also fixes those problems: now the error message is clear and tells that `data` cannot be a matrix.

The PR deletes function `ordiGetData` which was added in **vegan_1.8-4** to remove some scoping issues. The same functionality should be achieved by the current code with standard `eval()` function. 

I also noticed that the left-hand-side (community or community dissimilarities) were evaluated twice in distance-based `dbrda` and `capscale` and this could be costly. For instance, the lhs could be function `stepacross(vegdist(x))` which can be really expensive for large data sets. Now the lhs is no longer re-evaluated when it was already evaluated in distance-based methos.