### PR TITLE
eval LHS in the environment(formula)

### DIFF
--- a/R/bioenv.formula.R
+++ b/R/bioenv.formula.R
@@ -1,11 +1,11 @@
 `bioenv.formula` <-
-    function (formula, data, ...) 
+    function (formula, data, ...)
 {
-    if (missing(data)) 
+    if (missing(data))
         data <- parent.frame()
     fla <- formula
     comm <- formula[[2]]
-    comm <- eval(comm, data, parent.frame())
+    comm <- eval(comm, environment(formula), parent.frame())
     formula[[2]] <- NULL
     env <- model.frame(formula, data, na.action = NULL)
     out <- bioenv(comm, env, ...)

--- a/R/bioenv.formula.R
+++ b/R/bioenv.formula.R
@@ -2,7 +2,7 @@
     function (formula, data, ...)
 {
     if (missing(data))
-        data <- parent.frame()
+        data <- environment(formula)
     fla <- formula
     comm <- formula[[2]]
     comm <- eval(comm, environment(formula), parent.frame())

--- a/R/envfit.formula.R
+++ b/R/envfit.formula.R
@@ -1,10 +1,10 @@
-"envfit.formula" <-
+`envfit.formula` <-
     function(formula, data, ...)
 {
     if (missing(data))
-        data <- parent.frame()
+        data <- environment(formula)
     X <- formula[[2]]
-    X <- eval(X, data, parent.frame())
+    X <- eval(X, environment(formula), enclos = .GlobalEnv)
     formula[[2]] <- NULL
     P <- model.frame(formula, data, na.action = na.pass)
     envfit.default(X, P, ...)

--- a/R/hierParseFormula.R
+++ b/R/hierParseFormula.R
@@ -1,14 +1,14 @@
-"hierParseFormula" <-
-function (formula, data)
+`hierParseFormula` <-
+    function (formula, data)
 {
     lhs <- formula[[2]]
-    if (any(attr(terms(formula, data = data), "order") > 1)) 
+    if (any(attr(terms(formula, data = data), "order") > 1))
         stop("interactions are not allowed")
-    lhs <- as.matrix(eval(lhs, data))
+    lhs <- as.matrix(eval(lhs, environment(formula), parent.frame()))
     formula[[2]] <- NULL
     rhs <- model.frame(formula, data, drop.unused.levels = TRUE)
     rhs[] <- lapply(rhs, function(u) {
-        if (!is.factor(u)) 
+        if (!is.factor(u))
             u <- factor(u)
         u
     })


### PR DESCRIPTION
Several functions used `eval(formula[[2]], data)` which should never work for the LHS (but works because `.GlobalEnv` is the enclosing environment). Now we always use `eval(formula[[2]], environment(formula))` which should be more robust and embeddable. However, this breaks the case where the LHS is univariate response from the `data`. This should never be the case with `envfit` where the LHS is an ordination object or `adipart`  etc where the LHS is a multispecies community, but it potentially breaks `bioenv` with univariate response. However, the use of univariate response from the `data` is against current documentation and the fix accords with the existing documentation.

As a side effect this fixes a misleading error message when `data` was a matrix that was the concern in issue #200.