### PR TITLE
Allow for ordicluster and related functions to return details of what was drawn and allow suppression of plotting

### DIFF
--- a/R/ordicluster.R
+++ b/R/ordicluster.R
@@ -1,6 +1,6 @@
 `ordicluster` <-
-    function (ord, cluster, prune=0, display="sites",
-              w = weights(ord, display), col = 1, ...)
+    function (ord, cluster, prune = 0, display = "sites",
+              w = weights(ord, display), col = 1, plot = TRUE, ...)
 {
     weights.default <- function(object, ...) NULL
     w <- eval(w)
@@ -16,7 +16,8 @@
     col <- rep(col, length = nrow(ord))
     col <- col2rgb(col)/255
     nodecol <- matrix(NA, nrow(mrg) - prune, 3)
-    for (i in 1: (nrow(mrg) - prune)) {
+    seg.coords <- matrix(NA, nrow = nrow(mrg) - prune, ncol = 4)
+    for (i in seq_len(nrow(mrg) - prune)) {
         a <- mrg[i,1]
         b <- mrg[i,2]
         one <- if (a < 0) ord[-a,] else go[a,]
@@ -30,9 +31,16 @@
         colone <- if (a < 0) col[,-a] else nodecol[a,]
         coltwo <- if (b < 0) col[,-b] else nodecol[b,]
         nodecol[i,] <- (n1 * colone + n2 * coltwo)/noden[i]
-        ordiArgAbsorber(one[1], one[2], two[1], two[2],
-                        col = rgb(t(nodecol[i,])),
+        seg.coords[i, ] <- c(one[1], one[2], two[1], two[2])
+    }
+    colnames(seg.coords) <- c("x1","y1","x2","y2")
+    seg.coords <- cbind(seg.coords, col = nodecol)
+    if (plot) {
+        ordiArgAbsorber(seg.coords[,1L], seg.coords[,2L], seg.coords[,3L], seg.coords[,4L],
+                        col = rgb(nodecol),
                         FUN = segments, ...)
     }
-    invisible(cbind(go, "w"=noden))
+    out <- structure(list(scores = cbind(go, "w" = noden),
+                          segments = seg.coords), class = "ordicluster")
+    invisible(out)
 }

--- a/R/ordicluster.R
+++ b/R/ordicluster.R
@@ -1,6 +1,7 @@
 `ordicluster` <-
     function (ord, cluster, prune = 0, display = "sites",
-              w = weights(ord, display), col = 1, plot = TRUE, ...)
+              w = weights(ord, display), col = 1,
+              draw = c("segments", "none"), ...)
 {
     weights.default <- function(object, ...) NULL
     w <- eval(w)
@@ -35,8 +36,11 @@
     }
     colnames(seg.coords) <- c("x1","y1","x2","y2")
     seg.coords <- cbind(seg.coords, col = nodecol)
-    if (plot) {
-        ordiArgAbsorber(seg.coords[,1L], seg.coords[,2L], seg.coords[,3L], seg.coords[,4L],
+    ## are we plotting?
+    draw <- match.arg(draw)
+    if (isTRUE(all.equal(draw, "segments"))) {
+        ordiArgAbsorber(seg.coords[,1L], seg.coords[,2L],
+                        seg.coords[,3L], seg.coords[,4L],
                         col = rgb(nodecol),
                         FUN = segments, ...)
     }

--- a/man/ordihull.Rd
+++ b/man/ordihull.Rd
@@ -34,7 +34,8 @@ ordispider(ord, groups, display="sites", w = weights(ord, display),
 	 spiders = c("centroid", "median"),  show.groups, 
          label = FALSE, col = NULL, lty = NULL, lwd = NULL, ...)
 ordicluster(ord, cluster, prune = 0, display = "sites",
-            w = weights(ord, display), col = 1, plot = TRUE, ...)
+            w = weights(ord, display), col = 1, draw = c("segments", "none"),
+            ...)
 \method{summary}{ordihull}(object, ...)
 \method{summary}{ordiellipse}(object, ...)
 ordiareatest(ord, groups, area = c("hull", "ellipse"), kind = "sd",
@@ -47,11 +48,15 @@ ordiareatest(ord, groups, area = c("hull", "ellipse"), kind = "sd",
     drawn. }
   \item{display}{Item to displayed. }
 
-  \item{draw}{Use either \code{\link{lines}} or \code{\link{polygon}}
-    to draw the lines. Graphical parameters are passed to both. The
-    main difference is that \code{polygon}s may be filled and
-    non-transparent. With \code{none} nothing is drawn, but the
-    function returns the \code{\link{invisible}} plotting data.}
+  \item{draw}{character; how should objects be represented on the plot?
+    For \code{ordihull} and \code{ordiellipse} use either
+    \code{\link{lines}} or \code{\link{polygon}} to draw the
+    lines. For \code{ordicluster}, line segments are drawn using
+    \code{\link{segments}}. To suppress plotting, use
+    \code{"none"}. Graphical parameters are passed to both. The main
+    difference is that \code{polygon}s may be filled and
+    non-transparent. With \code{none} nothing is drawn, but the function
+    returns the \code{\link{invisible}} plotting.}
 
   \item{col}{Colour of hull or ellipse lines (if \code{draw = "lines"})
     or their fills (if \code{draw = "polygon"}) in \code{ordihull} and
@@ -105,9 +110,6 @@ ordiareatest(ord, groups, area = c("hull", "ellipse"), kind = "sd",
   \item{prune}{Number of upper level hierarchies removed from the
     dendrogram. If \code{prune} \eqn{>0}, dendrogram will be
     disconnected.}
-
-  \item{plot}{logical; for \code{ordicluster}, whether to draw anything
-    on the current device.}
 
   \item{object}{A result object from \code{ordihull} or
     \code{ordiellipse}. The result is \code{\link{invisible}}, but it

--- a/man/ordihull.Rd
+++ b/man/ordihull.Rd
@@ -34,7 +34,7 @@ ordispider(ord, groups, display="sites", w = weights(ord, display),
 	 spiders = c("centroid", "median"),  show.groups, 
          label = FALSE, col = NULL, lty = NULL, lwd = NULL, ...)
 ordicluster(ord, cluster, prune = 0, display = "sites",
-         w = weights(ord, display), col = 1, ...)
+            w = weights(ord, display), col = 1, plot = TRUE, ...)
 \method{summary}{ordihull}(object, ...)
 \method{summary}{ordiellipse}(object, ...)
 ordiareatest(ord, groups, area = c("hull", "ellipse"), kind = "sd",
@@ -105,6 +105,9 @@ ordiareatest(ord, groups, area = c("hull", "ellipse"), kind = "sd",
   \item{prune}{Number of upper level hierarchies removed from the
     dendrogram. If \code{prune} \eqn{>0}, dendrogram will be
     disconnected.}
+
+  \item{plot}{logical; for \code{ordicluster}, whether to draw anything
+    on the current device.}
 
   \item{object}{A result object from \code{ordihull} or
     \code{ordiellipse}. The result is \code{\link{invisible}}, but it


### PR DESCRIPTION
It would be useful to call `ordicluster` and possibly other functions documented in `ordihull.Rd` without the side effect of drawing on the current device. In the case of `ordicluster` it would be useful to have the segment `x` and `y` coordinates (and possibly colours) that would be drawn returned.

These could then be used for custom plotting by experts or by other packages, like **ggvegan**, to allow reproducing of **vegan**'s base graphics plots in other plotting engines.

This PR is a work in progress and the first implementation of an idea along the lines of the above. This affects only `ordicluster` and form and documentation of the returned object is not fixed.

The PR currently:
- adds arg `plot` to suppress plotting
- returns the segments and colours as drawn
- refactors to do a single call to `segments`

The latter is a logical conclusion of storing all the information for plotting and should probably be adopted even if we don't end up implementing the changes to `ordicluster` & co.
