### PR TITLE
Sequential tests in permutest.cca

### DIFF
--- a/R/ordiParseFormula.R
+++ b/R/ordiParseFormula.R
@@ -94,10 +94,15 @@ function (formula, data, xlev = NULL, na.action = na.fail,
     }
     if (NROW(mf) > 0) {
         Y <- model.matrix(formula, mf)
+        ## save assign attribute
+        assign <- attr(Y, "assign")
+        assign <- assign[assign > 0]
         if (any(colnames(Y) == "(Intercept)"))
             Y <- Y[, -which(colnames(Y) == "(Intercept)"), drop = FALSE]
         if (NCOL(Y) == 0)
             Y <- NULL
+        else
+            attr(Y, "assign") <- assign
     }
     X <- as.matrix(X)
     rownames(X) <- rownames(X, do.NULL = FALSE)

--- a/R/ordiTerminfo.R
+++ b/R/ordiTerminfo.R
@@ -1,4 +1,4 @@
-"ordiTerminfo" <-
+`ordiTerminfo` <-
     function(d, data)
 {
     Terms <- delete.response(d$terms.expand)
@@ -8,5 +8,6 @@
         mf <- d$modelframe
     xlev <- .getXlevels(Terms, mf)
     ordered <- sapply(mf, is.ordered)
-    list(terms = Terms, xlev = xlev, ordered = ordered)
+    assign <- attr(d$Y, "assign")
+    list(terms = Terms, assign = assign, xlev = xlev, ordered = ordered)
 }

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -110,15 +110,24 @@ permutest.default <- function(x, ...)
     }
     ## effects
     if (!is.null(by)) {
-        if (by == "onedf")
+        if (by == "onedf") {
             effects <- seq_len(q)
-        else {                   # by = "terms"
+            termlabs <-
+                if (isPartial)
+                    colnames(x$CCA$QR$qr)[effects + x$pCCA$rank]
+                else
+                    colnames(x$CCA$QR$qr)[effects]
+        } else {                   # by = "terms"
             ass <- x$terminfo$assign
             pivot <- x$CCA$QR$pivot
             if (isPartial)
                 pivot <- pivot[pivot > x$pCCA$rank] - x$pCCA$rank
             ass <- ass[pivot[seq_len(x$CCA$qrank)]]
             effects <- cumsum(rle(ass)$length)
+            termlabs <- labels(terms(x$terminfo))
+            if (isPartial)
+                termlabs <- termlabs[termlabs %in% labels(terms(x))]
+            termlabs <-termlabs[unique(ass)]
         }
         q <- diff(c(0, effects)) # d.o.f.
         if (isPartial)
@@ -129,8 +138,10 @@ permutest.default <- function(x, ...)
             F.0[k] <- if (isDB) sum(diag(fv)) else sum(fv^2)
         }
     }
-    else
+    else {
         effects <- 0
+        termlabs <- "Model"
+    }
     ## Set up
     Chi.xz <- x$CA$tot.chi
     names(Chi.xz) <- "Residual"
@@ -204,7 +215,7 @@ permutest.default <- function(x, ...)
     sol <- list(call = Call, testcall = x$call, model = model,
                 F.0 = F.0, F.perm = F.perm,  chi = c(Chi.z, Chi.xz),
                 num = num, den = den, df = c(q, r), nperm = nperm,
-                method = x$method, first = first)
+                method = x$method, first = first, termlabels = termlabs)
     sol$Random.seed <- attr(permutations, "seed")
     sol$control <- attr(permutations, "control")
     if (!missing(strata)) {

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -20,6 +20,9 @@ permutest.default <- function(x, ...)
         class(sol) <- "permutest.cca"
         return(sol)
     }
+    ## compatible arguments?
+    if (!is.null(by) && (first || !C))
+        stop("'by' cannot be used with options 'first=TRUE' or 'C=FALSE'")
     model <- match.arg(model)
     ## special cases
     isCCA <- !inherits(x, "rda")    # weighting

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -97,8 +97,11 @@ permutest.default <- function(x, ...)
         q <- x$CCA$qrank
     }
     ## effects
-    if (!is.null(by))
+    if (!is.null(by)) {
         effects <- seq_len(q)
+        if (isPartial)
+            effects <- effects + x$pCCA$rank
+    }
     else
         effects <- q
     ## Set up

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -176,7 +176,7 @@ permutest.default <- function(x, ...)
     } else {
         num <- tmp[,1]
         den <- tmp[,2]
-        F.perm <- tmp[,3]
+        F.perm <- tmp[,3, drop=FALSE]
     }
     Call <- match.call()
     Call[[1]] <- as.name("permutest")

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -73,7 +73,7 @@ permutest.default <- function(x, ...)
     {
         if (!is.matrix(indx))
             indx <- matrix(indx, nrow=1)
-        out <- .Call("do_getF", indx, E, Q, QZ, first, isPartial, isDB)
+        out <- .Call("do_getF", indx, E, Q, QZ, q, first, isPartial, isDB)
         if (!isPartial && !first)
             out[,2] <- Chi.tot - out[,1]
         out <- cbind(out, (out[,1]/q)/(out[,2]/r))

--- a/R/print.permutest.cca.R
+++ b/R/print.permutest.cca.R
@@ -1,19 +1,25 @@
 `print.permutest.cca` <-
-    function (x, ...) 
+    function (x, ...)
 {
     EPS <- sqrt(.Machine$double.eps)
     cat("\nPermutation test for", x$method, "\n\n")
     cat(howHead(x$control), "\n")
     writeLines(strwrap(pasteCall(x$testcall)))
-    Pval <- (sum(x$F.perm >= x$F.0 - EPS) + 1)/(x$nperm + 1)
+    Pval <- (colSums(sweep(x$F.perm, 2, x$F.0 - EPS, ">=")) + 1)/(x$nperm + 1)
     cat("Permutation test for ")
     if (x$first)
         cat("first constrained eigenvalue\n")
-    else
+    else if (length(x$df) <= 2)
         cat("all constrained eigenvalues\n")
-    cat("Pseudo-F:\t", x$F.0, "(with", paste(x$df, collapse = ", "),
-        "Degrees of Freedom)\n")
-    cat("Significance:\t", format.pval(Pval), 
-        "\n\n")
+    else
+        cat("sequential contrasts\n")
+    anotab <- data.frame(x$df, x$chi, c(x$F.0, NA), c(Pval, NA))
+    colnames(anotab) <- c("Df", "Inertia", "F", "Pr(>F)")
+    if (nrow(anotab) == 2)
+        rownames(anotab) <- c("Model", "Residual")
+    else
+        rownames(anotab)[nrow(anotab)] <- "Residual"
+    class(anotab) <- c("anova", "data.frame")
+    print(anotab)
     invisible(x)
 }

--- a/R/print.permutest.cca.R
+++ b/R/print.permutest.cca.R
@@ -2,7 +2,7 @@
     function (x, ...)
 {
     EPS <- sqrt(.Machine$double.eps)
-    cat("\nPermutation test for", x$method, "\n\n")
+    cat("\nPermutation test for", x$method, "under", x$model, "model", "\n\n")
     cat(howHead(x$control), "\n")
     writeLines(strwrap(pasteCall(x$testcall)))
     Pval <- (colSums(sweep(x$F.perm, 2, x$F.0 - EPS, ">=")) + 1)/(x$nperm + 1)
@@ -15,10 +15,7 @@
         cat("sequential contrasts\n")
     anotab <- data.frame(x$df, x$chi, c(x$F.0, NA), c(Pval, NA))
     colnames(anotab) <- c("Df", "Inertia", "F", "Pr(>F)")
-    if (nrow(anotab) == 2)
-        rownames(anotab) <- c("Model", "Residual")
-    else
-        rownames(anotab)[nrow(anotab)] <- "Residual"
+    rownames(anotab) <- c(x$termlabels, "Residual")
     class(anotab) <- c("anova", "data.frame")
     print(anotab)
     invisible(x)

--- a/man/anova.cca.Rd
+++ b/man/anova.cca.Rd
@@ -49,7 +49,9 @@
     significance for each term (sequentially from first to last), and
     setting \code{by = "margin"} will assess the marginal effects of
     the terms (each marginal term analysed in a model with all other
-    variables)}
+    variables). Function \code{permutest} accepts choices
+    \code{"terms"} for sequential test of terms, and \code{"onedf"}
+    for sequential test of one-degree-of-freedom constrasts.}
 
   \item{model}{Permutation model: \code{model="direct"} permutes 
     community data, \code{model="reduced"} permutes residuals

--- a/man/anova.cca.Rd
+++ b/man/anova.cca.Rd
@@ -25,8 +25,8 @@
      parallel = getOption("mc.cores"), strata = NULL,
      cutoff = 1, scope = NULL)
 \method{permutest}{cca}(x, permutations = how(nperm = 99), 
-     model = c("reduced", "direct", "full"), first = FALSE, strata = NULL,
-     parallel = getOption("mc.cores"), C = TRUE, ...)
+     model = c("reduced", "direct", "full"), by = NULL, first = FALSE,
+     strata = NULL, parallel = getOption("mc.cores"), C = TRUE, ...)
 }
 
 \arguments{

--- a/man/cca.object.Rd
+++ b/man/cca.object.Rd
@@ -38,15 +38,15 @@
   \item{terms}{The \code{\link{terms}} component of the
     \code{\link{formula}}. This is missing if the ordination was not called
     with \code{formula}.}
-  \item{terminfo}{Further information on terms with three subitems:
+  \item{terminfo}{Further information on terms with four subitems:
     \code{terms} which is like the \code{terms} component above, but
-    lists conditions and constraints similarly;  \code{xlev}
-    which lists the factor levels, and \code{ordered} which is
-    \code{TRUE} to ordered factors.
-    This is produced by \pkg{vegan} internal function
-    \code{\link{ordiTerminfo}}, and it is needed in
-    \code{\link{predict.cca}} with \code{newdata}.  This is missing if
-    the ordination was not called with \code{formula}.}
+    lists conditions and constraints similarly; \code{assign} which is
+    the \code{assign} attribute of constraining
+    \code{\link{model.matrix}}, \code{xlev} which lists the factor
+    levels, and \code{ordered} which is \code{TRUE} to ordered
+    factors.  This is produced by \pkg{vegan} internal function
+    \code{\link{ordiTerminfo}}, and is missing if the ordination
+    was not called with \code{formula}.}
   \item{tot.chi}{Total inertia or the sum of all eigenvalues.}
   \item{na.action}{The result of \code{\link{na.action}} if missing
     values in constraints were handled by \code{\link{na.omit}} or

--- a/src/getF.c
+++ b/src/getF.c
@@ -11,7 +11,7 @@
 #include <R_ext/Lapack.h>  /* SVD, eigen */
 
 #include <math.h> /* sqrt */
-#include <string.h> /* memcpy */
+#include <string.h> /* memcpy, memset */
 
 /* LINPACK uses the same function (dqrsl) to find derived results from
  * the QR decomposition. It uses decimal coding to define the kind of
@@ -159,6 +159,7 @@ SEXP do_getF(SEXP perms, SEXP E, SEXP QR, SEXP QZ, SEXP effects,
     double ev1, ev0, ev;
     SEXP ans = PROTECT(allocMatrix(REALSXP, nperm, nterms + 1));
     double *rans = REAL(ans);
+    memset(rans, 0, nperm * (nterms + 1) * sizeof(double));
     SEXP Y = PROTECT(duplicate(E));
     double *rY = REAL(Y);
     if (TYPEOF(effects) != INTSXP)

--- a/src/getF.c
+++ b/src/getF.c
@@ -152,7 +152,7 @@ static void transpose(double *x, double *tx, int nr, int nc)
 SEXP do_getF(SEXP perms, SEXP E, SEXP QR, SEXP QZ, SEXP effects,
 	     SEXP first, SEXP isPartial, SEXP isDB)
 {
-    int i, j, k, ki, p, nterms = LENGTH(effects),
+    int i, j, k, ki, p, nterms = length(effects),
 	nperm = nrows(perms), nr = nrows(E), nc = ncols(E),
 	FIRST = asInteger(first), PARTIAL = asInteger(isPartial),
 	DISTBASED = asInteger(isDB);

--- a/src/getF.c
+++ b/src/getF.c
@@ -287,7 +287,7 @@ SEXP do_getF(SEXP perms, SEXP E, SEXP QR, SEXP QZ, SEXP effects,
 		getEV(fitted, nr, nc, DISTBASED) - ev0;
 	}
 	if (PARTIAL || FIRST)
-	    rans[k + nperm] = getEV(resid, nr, nc, DISTBASED);
+	    rans[k + nterms * nperm] = getEV(resid, nr, nc, DISTBASED);
 
     } /* end permutation loop */
 


### PR DESCRIPTION
I have implemented permutations tests for constrained ordination methods in **C**. When doing this, I noticed that it would be easy to move sequential tests as the innermost loop of the **C** code with potential speed-up. Currently the sequential models are the outermost loop: we use `anova.ccalist` function which takes a list of models, runs `permutests.cca` to each of these, and subtracts the permutation result of the previous model. All this is potentially very slow.

The current PR is the first step of migration for sequential models. The sequential models are implemented in `permutest.cca`, but `anova.cca(..., by = "term")` still uses the old code. This allows testing of accuracy and speed. Both functions will still use **C** code in permutations, because `anova.cca(..., by = "term")` cannot pass argument `C = FALSE` to `permutest.cca`. 

The sequential tests are triggered with argument `by` like in `anova.cca`. There are two alternatives: `by = "terms"` is similar to `anova.cca(..., by = "term")` and returns identical permutations statistics with identical permutations. There is also alternative `by = "onedf"`  for sequential test of all one-degree-of-freedom-contrasts. This will break factor variables to their contrasts:

```R
## Moisture is a 3-df ordered factor with polynomial contrasts
> permutest(cca(dune ~ Moisture, dune.env), by = "onedf", perm=999)

Permutation test for cca under reduced model 

Permutation: free
Number of permutations: 999
 
Call: cca(formula = dune ~ Moisture, data = dune.env)
Permutation test for sequential contrasts
           Df Inertia      F Pr(>F)    
Moisture.L  1 0.41081 4.4204  0.001 ***
Moisture.Q  1 0.11261 1.2117  0.240    
Moisture.C  1 0.10489 1.1287  0.315    
Residual   16 1.48695                  
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
```
(The formatting of `permutest.cca` output is now mostly similar to `anova.cca`, too).

The next stage would be to change sequential tests to use this new code and clean up `permutest.cca`. Most of our tests are marginal, and they are not affected by this change. 

The feature is implemented so that the **C** function has new argument `effects` that is a vector of cumulative degrees-of-freedom where the models should be evaluated. This passed to the **Fortran** code for QR decomposition similarly as argument `k` in `stats::qr.fitted()`. However, `permutest.cca` does not have this argument, but it has argument `by` that constructs the `effects` vector either by one-degree-of-freedom contrasts, or corresponding to degrees of freedom of original constraining variables (after potential aliasing). An alternative implementation would keep `permutest.cca` as a lower-level function that also has `effects` arguments, and let `anova.cca(..., by=)` cases construct their `effects` vector and pass it to `permutest.cca`.