### PR TITLE
Added iterations to rrarefy

### DIFF
--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -1,32 +1,46 @@
 ### Random rarefied subsample: sample without replacement
 
 `rrarefy` <-
-    function(x, sample)
+    function(x, sample, iterations = 1)
 {
     if (!identical(all.equal(x, round(x)), TRUE)) 
         stop("function is meaningful only for integers (counts)")
     x <- as.matrix(x)
-    if (ncol(x) == 1)
+    if (ncol(x) == 1) 
         x <- t(x)
-    if (length(sample) > 1 && length(sample) != nrow(x))
-        stop(gettextf(
-             "length of 'sample' and number of rows of 'x' do not match"))
-    sample <- rep(sample, length=nrow(x))
+    if (length(sample) > 1 && length(sample) != nrow(x)) 
+        stop(gettextf("length of 'sample' and number of rows of 'x' do not match"))
+    sample <- rep(sample, length = nrow(x))
     colnames(x) <- colnames(x, do.NULL = FALSE)
     nm <- colnames(x)
-    ## warn if something cannot be rarefied
-    if (any(rowSums(x) < sample))
+    if (any(rowSums(x) < sample)) 
         warning("Some row sums < 'sample' and are not rarefied")
     for (i in 1:nrow(x)) {
-        if (sum(x[i,]) <= sample[i]) ## nothing to rarefy: take all
+        if (sum(x[i, ]) <= sample[i]) 
             next
-        row <- sample(rep(nm, times=x[i,]), sample[i])
+        row <- sample(rep(nm, times = x[i, ]), sample[i])
         row <- table(row)
         ind <- names(row)
-        x[i,] <- 0
-        x[i,ind] <- row
+        y <- x
+        y[i, ] <- 0
+        y[i, ind] <- row
+        counter <- 1
+        if(iterations > 1) {
+            z <- x
+            itr <- iterations-1
+            for(k in c(1:itr)) {
+                row <- sample(rep(nm, times = x[i, ]), sample[i])
+                row <- table(row)
+                ind <- names(row)
+                z[i, ] <- 0
+                z[i, ind] <- row
+                z[i,] <- y[i,] + (1/(counter + 1)) * (z[i,] - y[i,])
+                y[i,] <- z[i,]
+                counter <- counter + 1
+            }
+        }
     }
-    x
+    y
 }
 
 ### Probabilities that species occur in a rarefied 'sample'

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -1,46 +1,36 @@
 ### Random rarefied subsample: sample without replacement
 
 `rrarefy` <-
-    function(x, sample, iterations = 1)
+    function(x, sample, average = FALSE)
 {
     if (!identical(all.equal(x, round(x)), TRUE)) 
         stop("function is meaningful only for integers (counts)")
     x <- as.matrix(x)
-    if (ncol(x) == 1) 
+    if (ncol(x) == 1)
         x <- t(x)
-    if (length(sample) > 1 && length(sample) != nrow(x)) 
-        stop(gettextf("length of 'sample' and number of rows of 'x' do not match"))
-    sample <- rep(sample, length = nrow(x))
+    if (length(sample) > 1 && length(sample) != nrow(x))
+        stop(gettextf(
+             "length of 'sample' and number of rows of 'x' do not match"))
+    sample <- rep(sample, length=nrow(x))
     colnames(x) <- colnames(x, do.NULL = FALSE)
     nm <- colnames(x)
-    if (any(rowSums(x) < sample)) 
+    ## warn if something cannot be rarefied
+    if (any(rowSums(x) < sample))
         warning("Some row sums < 'sample' and are not rarefied")
-    y <- x
     for (i in 1:nrow(x)) {
-        if (sum(x[i, ]) <= sample[i]) 
+        if (sum(x[i,]) <= sample[i]) ## nothing to rarefy: take all
             next
-        row <- sample(rep(nm, times = x[i, ]), sample[i])
-        row <- table(row)
-        ind <- names(row)
-        y[i, ] <- 0
-        y[i, ind] <- row
-        counter <- 1
-        if(iterations > 1) {
-            z <- x
-            itr <- iterations-1
-            for(k in c(1:itr)) {
-                row <- sample(rep(nm, times = x[i, ]), sample[i])
-                row <- table(row)
-                ind <- names(row)
-                z[i, ] <- 0
-                z[i, ind] <- row
-                z[i,] <- y[i,] + (1/(counter + 1)) * (z[i,] - y[i,])
-                y[i,] <- z[i,]
-                counter <- counter + 1
-            }
+        if (average) {
+            x <- x / rowSums(x) * sample
+        } else {
+            row <- sample(rep(nm, times=x[i,]), sample[i])
+            row <- table(row)
+            ind <- names(row)
+            x[i,] <- 0
+            x[i,ind] <- row
         }
     }
-    y
+    x
 }
 
 ### Probabilities that species occur in a rarefied 'sample'

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -15,13 +15,13 @@
     nm <- colnames(x)
     if (any(rowSums(x) < sample)) 
         warning("Some row sums < 'sample' and are not rarefied")
+    y <- x
     for (i in 1:nrow(x)) {
         if (sum(x[i, ]) <= sample[i]) 
             next
         row <- sample(rep(nm, times = x[i, ]), sample[i])
         row <- table(row)
         ind <- names(row)
-        y <- x
         y[i, ] <- 0
         y[i, ind] <- row
         counter <- 1

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -22,6 +22,7 @@
             next
         if (average) {
             x <- x / rowSums(x) * sample
+            x <- ifelse(x >= (sample)^-1, x, 0)
         } else {
             row <- sample(rep(nm, times=x[i,]), sample[i])
             row <- table(row)

--- a/man/rarefy.Rd
+++ b/man/rarefy.Rd
@@ -11,7 +11,7 @@
 
 \usage{
 rarefy(x, sample, se = FALSE, MARGIN = 1)
-rrarefy(x, sample, iterations = 1)
+rrarefy(x, sample, average = FALSE)
 drarefy(x, sample)
 rarecurve(x, step = 1, sample, xlab = "Sample Size", ylab = "Species",
           label = TRUE, col, lty, ...)
@@ -24,7 +24,7 @@ rareslope(x, sample)
   \item{sample}{Subsample size for rarefying community, either a single
     value or a vector.}
   \item{se}{Estimate standard errors.}
-  \item{iterations}{Number of iterations for averaging subsampling.}
+  \item{average}{Calculate the equalized averages whe subsampling (logical).}
   \item{step}{Step size for sample sizes in rarefaction curves.}
   \item{xlab, ylab}{Axis labels in plots of rarefaction curves.}
   \item{label}{Label rarefaction curves by rownames of \code{x}

--- a/man/rarefy.Rd
+++ b/man/rarefy.Rd
@@ -11,7 +11,7 @@
 
 \usage{
 rarefy(x, sample, se = FALSE, MARGIN = 1)
-rrarefy(x, sample)
+rrarefy(x, sample, iterations = 1)
 drarefy(x, sample)
 rarecurve(x, step = 1, sample, xlab = "Sample Size", ylab = "Species",
           label = TRUE, col, lty, ...)

--- a/man/rarefy.Rd
+++ b/man/rarefy.Rd
@@ -24,6 +24,7 @@ rareslope(x, sample)
   \item{sample}{Subsample size for rarefying community, either a single
     value or a vector.}
   \item{se}{Estimate standard errors.}
+  \item{iterations}{Number of iterations for averaging subsampling.}
   \item{step}{Step size for sample sizes in rarefaction curves.}
   \item{xlab, ylab}{Axis labels in plots of rarefaction curves.}
   \item{label}{Label rarefaction curves by rownames of \code{x}


### PR DESCRIPTION
Some rarefaction tools allow the user to subsample their data sets using multiple random subsampling iterations and reporting the mean of the results.

I added this functionality to the `rrarefy` function. The user can now specify the use of more than one subsampling iteration to get the mean of the results. This is a relatively small update.