### PR TITLE
Registration of compiled functions

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 ## compiled code
-useDynLib(vegan, .registration = TRUE)
+useDynLib(vegan, .registration = TRUE, .fixes = "veg_")
 
 ## Export regular function names (no dots)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 ## compiled code
-useDynLib(vegan)
+useDynLib(vegan, .registration = TRUE)
 
 ## Export regular function names (no dots)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 ## compiled code
-useDynLib(vegan, .registration = TRUE, .fixes = "veg_")
+useDynLib(vegan, .registration = TRUE)
 
 ## Export regular function names (no dots)
 

--- a/R/decorana.R
+++ b/R/decorana.R
@@ -37,7 +37,7 @@
     v <- attr(veg, "v")
     v.fraction <- attr(veg, "fraction")
     adotj[adotj < Const3] <- Const3
-    CA <- .Call(do_decorana, veg, ira, iresc, short, mk, as.double(aidot),
+    CA <- .Call(veg_do_decorana, veg, ira, iresc, short, mk, as.double(aidot),
                 as.double(adotj))
     if (ira)
         dnames <- paste("RA", 1:4, sep = "")

--- a/R/decorana.R
+++ b/R/decorana.R
@@ -37,8 +37,8 @@
     v <- attr(veg, "v")
     v.fraction <- attr(veg, "fraction")
     adotj[adotj < Const3] <- Const3
-    CA <- .Call("do_decorana", veg, ira, iresc, short, mk, as.double(aidot),
-                as.double(adotj), PACKAGE = "vegan")
+    CA <- .Call(do_decorana, veg, ira, iresc, short, mk, as.double(aidot),
+                as.double(adotj))
     if (ira)
         dnames <- paste("RA", 1:4, sep = "")
     else dnames <- paste("DCA", 1:4, sep = "")

--- a/R/decorana.R
+++ b/R/decorana.R
@@ -37,7 +37,7 @@
     v <- attr(veg, "v")
     v.fraction <- attr(veg, "fraction")
     adotj[adotj < Const3] <- Const3
-    CA <- .Call(veg_do_decorana, veg, ira, iresc, short, mk, as.double(aidot),
+    CA <- .Call(do_decorana, veg, ira, iresc, short, mk, as.double(aidot),
                 as.double(adotj))
     if (ira)
         dnames <- paste("RA", 1:4, sep = "")

--- a/R/designdist.R
+++ b/R/designdist.R
@@ -16,7 +16,7 @@
     if (terms == "binary" || terms == "quadratic")
         x <- tcrossprod(x)
     if (terms == "minimum")
-        x <- .Call(do_minterms, as.matrix(x))
+        x <- .Call(veg_do_minterms, as.matrix(x))
     d <- diag(x)
     A <- as.dist(outer(rep(1, N), d))
     B <- as.dist(outer(d, rep(1, N)))
@@ -58,7 +58,7 @@
     N <- nrow(x)
     ## do_chaoterms returns a list with U, V which are non-classed
     ## vectors where the order of terms matches 'dist' objects
-    vu <- .Call(do_chaoterms, x)
+    vu <- .Call(veg_do_chaoterms, x)
     U <- vu$U
     V <- vu$V
     ## dissimilarities

--- a/R/designdist.R
+++ b/R/designdist.R
@@ -16,7 +16,7 @@
     if (terms == "binary" || terms == "quadratic")
         x <- tcrossprod(x)
     if (terms == "minimum")
-        x <- .Call("do_minterms", as.matrix(x), PACKAGE = "vegan")
+        x <- .Call(do_minterms, as.matrix(x))
     d <- diag(x)
     A <- as.dist(outer(rep(1, N), d))
     B <- as.dist(outer(d, rep(1, N)))
@@ -58,7 +58,7 @@
     N <- nrow(x)
     ## do_chaoterms returns a list with U, V which are non-classed
     ## vectors where the order of terms matches 'dist' objects
-    vu <- .Call("do_chaoterms", x, PACKAGE = "vegan")
+    vu <- .Call(do_chaoterms, x)
     U <- vu$U
     V <- vu$V
     ## dissimilarities

--- a/R/designdist.R
+++ b/R/designdist.R
@@ -16,7 +16,7 @@
     if (terms == "binary" || terms == "quadratic")
         x <- tcrossprod(x)
     if (terms == "minimum")
-        x <- .Call(veg_do_minterms, as.matrix(x))
+        x <- .Call(do_minterms, as.matrix(x))
     d <- diag(x)
     A <- as.dist(outer(rep(1, N), d))
     B <- as.dist(outer(d, rep(1, N)))
@@ -58,7 +58,7 @@
     N <- nrow(x)
     ## do_chaoterms returns a list with U, V which are non-classed
     ## vectors where the order of terms matches 'dist' objects
-    vu <- .Call(veg_do_chaoterms, x)
+    vu <- .Call(do_chaoterms, x)
     U <- vu$U
     V <- vu$V
     ## dissimilarities

--- a/R/distconnected.R
+++ b/R/distconnected.R
@@ -1,10 +1,10 @@
-"distconnected" <-
+`distconnected` <-
     function(dis, toolong = 1, trace = TRUE)
 {
     n <- attr(dis, "Size")
-    out <- .C("stepabyss", dis = as.double(dis), n = as.integer(n),
+    out <- .C(stepabyss, dis = as.double(dis), n = as.integer(n),
               toolong = as.double(toolong), val = integer(n),
-              NAOK = TRUE, PACKAGE = "vegan")$val
+              NAOK = TRUE)$val
     if (trace) {
         cat("Connectivity of distance matrix with threshold dissimilarity",
             toolong,"\n")

--- a/R/distconnected.R
+++ b/R/distconnected.R
@@ -2,7 +2,7 @@
     function(dis, toolong = 1, trace = TRUE)
 {
     n <- attr(dis, "Size")
-    out <- .C(veg_stepabyss, dis = as.double(dis), n = as.integer(n),
+    out <- .C(stepabyss, dis = as.double(dis), n = as.integer(n),
               toolong = as.double(toolong), val = integer(n),
               NAOK = TRUE)$val
     if (trace) {

--- a/R/distconnected.R
+++ b/R/distconnected.R
@@ -2,7 +2,7 @@
     function(dis, toolong = 1, trace = TRUE)
 {
     n <- attr(dis, "Size")
-    out <- .C(stepabyss, dis = as.double(dis), n = as.integer(n),
+    out <- .C(veg_stepabyss, dis = as.double(dis), n = as.integer(n),
               toolong = as.double(toolong), val = integer(n),
               NAOK = TRUE)$val
     if (trace) {

--- a/R/factorfit.R
+++ b/R/factorfit.R
@@ -19,7 +19,7 @@
         w <- rep(w, NR)
     r <- NULL
     pval <- NULL
-    totvar <- .Call(do_goffactor, X, rep(1L, NR), 1L, w)
+    totvar <- .Call(veg_do_goffactor, X, rep(1L, NR), 1L, w)
     sol <- centroids.cca(X, P, w)
     var.id <- rep(names(P), sapply(P, nlevels))
     ## make permutation matrix for all variables handled in the next loop
@@ -29,7 +29,7 @@
     for (i in seq_along(P)) {
         A <- as.integer(P[[i]])
         NL <- nlevels(P[[i]])
-        invar <- .Call(do_goffactor, X, A, NL, w)
+        invar <- .Call(veg_do_goffactor, X, A, NL, w)
         r.this <- 1 - invar/totvar
         r <- c(r, r.this)
         if (permutations) {
@@ -37,7 +37,7 @@
             NL <- nlevels(P[[i]])
             ptest <- function(indx, ...) {
                 take <- A[indx]
-                invar <- .Call(do_goffactor, X, take, NL, w)
+                invar <- .Call(veg_do_goffactor, X, take, NL, w)
                 1 - invar/totvar
             }
             tmp <- sapply(seq_len(permutations),

--- a/R/factorfit.R
+++ b/R/factorfit.R
@@ -19,7 +19,7 @@
         w <- rep(w, NR)
     r <- NULL
     pval <- NULL
-    totvar <- .Call(veg_do_goffactor, X, rep(1L, NR), 1L, w)
+    totvar <- .Call(do_goffactor, X, rep(1L, NR), 1L, w)
     sol <- centroids.cca(X, P, w)
     var.id <- rep(names(P), sapply(P, nlevels))
     ## make permutation matrix for all variables handled in the next loop
@@ -29,7 +29,7 @@
     for (i in seq_along(P)) {
         A <- as.integer(P[[i]])
         NL <- nlevels(P[[i]])
-        invar <- .Call(veg_do_goffactor, X, A, NL, w)
+        invar <- .Call(do_goffactor, X, A, NL, w)
         r.this <- 1 - invar/totvar
         r <- c(r, r.this)
         if (permutations) {
@@ -37,7 +37,7 @@
             NL <- nlevels(P[[i]])
             ptest <- function(indx, ...) {
                 take <- A[indx]
-                invar <- .Call(veg_do_goffactor, X, take, NL, w)
+                invar <- .Call(do_goffactor, X, take, NL, w)
                 1 - invar/totvar
             }
             tmp <- sapply(seq_len(permutations),

--- a/R/factorfit.R
+++ b/R/factorfit.R
@@ -19,7 +19,7 @@
         w <- rep(w, NR)
     r <- NULL
     pval <- NULL
-    totvar <- .Call("do_goffactor", X, rep(1L, NR), 1L, w, PACKAGE = "vegan")
+    totvar <- .Call(do_goffactor, X, rep(1L, NR), 1L, w)
     sol <- centroids.cca(X, P, w)
     var.id <- rep(names(P), sapply(P, nlevels))
     ## make permutation matrix for all variables handled in the next loop
@@ -29,7 +29,7 @@
     for (i in seq_along(P)) {
         A <- as.integer(P[[i]])
         NL <- nlevels(P[[i]])
-        invar <- .Call("do_goffactor", X, A, NL, w, PACKAGE = "vegan")
+        invar <- .Call(do_goffactor, X, A, NL, w)
         r.this <- 1 - invar/totvar
         r <- c(r, r.this)
         if (permutations) {
@@ -37,7 +37,7 @@
             NL <- nlevels(P[[i]])
             ptest <- function(indx, ...) {
                 take <- A[indx]
-                invar <- .Call("do_goffactor", X, take, NL, w, PACKAGE = "vegan")
+                invar <- .Call(do_goffactor, X, take, NL, w)
                 1 - invar/totvar
             }
             tmp <- sapply(seq_len(permutations),

--- a/R/make.commsim.R
+++ b/R/make.commsim.R
@@ -79,22 +79,22 @@ function(method)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(n, rs, cs)), c(nr, nc, n))
             storage.mode(out) <- "integer"
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
         }),
         "swap" = commsim(method="swap", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(veg_do_swap, as.matrix(x), n, thin, "swap")
+            .Call(do_swap, as.matrix(x), n, thin, "swap")
         }),
         "tswap" = commsim(method="tswap", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(veg_do_swap, as.matrix(x), n, thin, "trialswap")
+            .Call(do_swap, as.matrix(x), n, thin, "trialswap")
         }),
         "curveball" = commsim(method="curveball", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(veg_do_curveball, as.matrix(x), n, thin)
+            .Call(do_curveball, as.matrix(x), n, thin)
         }),
         "backtrack" = commsim(method="backtrack", binary=TRUE, isSeq=FALSE,
         mode="integer",
@@ -159,7 +159,7 @@ function(method)
         "swap_count" = commsim(method="swap_count", binary = FALSE,
         isSeq=TRUE, mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(veg_do_swap, as.matrix(x), n, thin, "swapcount")
+            .Call(do_swap, as.matrix(x), n, thin, "swapcount")
         }),
         "quasiswap_count" = commsim(method="quasiswap_count", binary=FALSE,
         isSeq=FALSE, mode="integer",
@@ -168,7 +168,7 @@ function(method)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(n, rs, cs)), c(nr, nc, n))
             storage.mode(out) <- "integer"
-            .Call(veg_do_qswap, out, n, fill, "rswapcount")
+            .Call(do_qswap, out, n, fill, "rswapcount")
         }),
         "swsh_samp" = commsim(method="swsh_samp", binary=FALSE, isSeq=FALSE,
         mode="double",
@@ -178,7 +178,7 @@ function(method)
             nz <- x[x > 0]
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
             ## do_qswap changes 'out' within the function
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             for (k in seq_len(n)) {
                 out[,,k][out[,,k] > 0] <- sample(nz) # we assume that length(nz)>1
@@ -195,7 +195,7 @@ function(method)
             }
             nz <- as.integer(x[x > 0])
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 out[,,k][out[,,k] > 0] <- indshuffle(nz - 1L) + 1L  # we assume that length(nz)>1
@@ -208,7 +208,7 @@ function(method)
             if (nr < 2L || nc < 2)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             I <- seq_len(nr)
             for (k in seq_len(n)) {
@@ -228,7 +228,7 @@ function(method)
             if (nr < 2L || nc < 2)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             J <- seq_len(nc)
             for (k in seq_len(n)) {
@@ -252,7 +252,7 @@ function(method)
             }
             I <- seq_len(nr)
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 for (i in I) {
@@ -275,7 +275,7 @@ function(method)
             }
             J <- seq_len(nc)
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(veg_do_qswap, out, n, thin, "quasiswap")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 for (j in J) {
@@ -291,12 +291,12 @@ function(method)
         "abuswap_r" = commsim(method="abuswap_r", binary=FALSE, isSeq=TRUE,
         mode="double",
         fun=function(x, n, nr, nc, cs, rs, rf, cf, s, fill, thin) {
-            .Call(veg_do_abuswap, as.matrix(x), n, thin, 1L)
+            .Call(do_abuswap, as.matrix(x), n, thin, 1L)
         }),
         "abuswap_c" = commsim(method="abuswap_c", binary=FALSE, isSeq=TRUE,
         mode="double",
         fun=function(x, n, nr, nc, cs, rs, rf, cf, s, fill, thin) {
-            .Call(veg_do_abuswap, as.matrix(x), n, thin, 0L)
+            .Call(do_abuswap, as.matrix(x), n, thin, 0L)
         }),
         "r00_samp" = commsim(method="r00_samp", binary=FALSE, isSeq=FALSE,
         mode="double",

--- a/R/make.commsim.R
+++ b/R/make.commsim.R
@@ -79,22 +79,22 @@ function(method)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(n, rs, cs)), c(nr, nc, n))
             storage.mode(out) <- "integer"
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
         }),
         "swap" = commsim(method="swap", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(do_swap, as.matrix(x), n, thin, "swap")
+            .Call(veg_do_swap, as.matrix(x), n, thin, "swap")
         }),
         "tswap" = commsim(method="tswap", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(do_swap, as.matrix(x), n, thin, "trialswap")
+            .Call(veg_do_swap, as.matrix(x), n, thin, "trialswap")
         }),
         "curveball" = commsim(method="curveball", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(do_curveball, as.matrix(x), n, thin)
+            .Call(veg_do_curveball, as.matrix(x), n, thin)
         }),
         "backtrack" = commsim(method="backtrack", binary=TRUE, isSeq=FALSE,
         mode="integer",
@@ -159,7 +159,7 @@ function(method)
         "swap_count" = commsim(method="swap_count", binary = FALSE,
         isSeq=TRUE, mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call(do_swap, as.matrix(x), n, thin, "swapcount")
+            .Call(veg_do_swap, as.matrix(x), n, thin, "swapcount")
         }),
         "quasiswap_count" = commsim(method="quasiswap_count", binary=FALSE,
         isSeq=FALSE, mode="integer",
@@ -168,7 +168,7 @@ function(method)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(n, rs, cs)), c(nr, nc, n))
             storage.mode(out) <- "integer"
-            .Call(do_qswap, out, n, fill, "rswapcount")
+            .Call(veg_do_qswap, out, n, fill, "rswapcount")
         }),
         "swsh_samp" = commsim(method="swsh_samp", binary=FALSE, isSeq=FALSE,
         mode="double",
@@ -178,7 +178,7 @@ function(method)
             nz <- x[x > 0]
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
             ## do_qswap changes 'out' within the function
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             for (k in seq_len(n)) {
                 out[,,k][out[,,k] > 0] <- sample(nz) # we assume that length(nz)>1
@@ -195,7 +195,7 @@ function(method)
             }
             nz <- as.integer(x[x > 0])
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 out[,,k][out[,,k] > 0] <- indshuffle(nz - 1L) + 1L  # we assume that length(nz)>1
@@ -208,7 +208,7 @@ function(method)
             if (nr < 2L || nc < 2)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             I <- seq_len(nr)
             for (k in seq_len(n)) {
@@ -228,7 +228,7 @@ function(method)
             if (nr < 2L || nc < 2)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             J <- seq_len(nc)
             for (k in seq_len(n)) {
@@ -252,7 +252,7 @@ function(method)
             }
             I <- seq_len(nr)
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 for (i in I) {
@@ -275,7 +275,7 @@ function(method)
             }
             J <- seq_len(nc)
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call(do_qswap, out, n, thin, "quasiswap")
+            .Call(veg_do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 for (j in J) {
@@ -291,12 +291,12 @@ function(method)
         "abuswap_r" = commsim(method="abuswap_r", binary=FALSE, isSeq=TRUE,
         mode="double",
         fun=function(x, n, nr, nc, cs, rs, rf, cf, s, fill, thin) {
-            .Call(do_abuswap, as.matrix(x), n, thin, 1L)
+            .Call(veg_do_abuswap, as.matrix(x), n, thin, 1L)
         }),
         "abuswap_c" = commsim(method="abuswap_c", binary=FALSE, isSeq=TRUE,
         mode="double",
         fun=function(x, n, nr, nc, cs, rs, rf, cf, s, fill, thin) {
-            .Call(do_abuswap, as.matrix(x), n, thin, 0L)
+            .Call(veg_do_abuswap, as.matrix(x), n, thin, 0L)
         }),
         "r00_samp" = commsim(method="r00_samp", binary=FALSE, isSeq=FALSE,
         mode="double",

--- a/R/make.commsim.R
+++ b/R/make.commsim.R
@@ -79,24 +79,22 @@ function(method)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(n, rs, cs)), c(nr, nc, n))
             storage.mode(out) <- "integer"
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
         }),
         "swap" = commsim(method="swap", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call("do_swap", as.matrix(x), n, thin, "swap",
-                  PACKAGE = "vegan")
+            .Call(do_swap, as.matrix(x), n, thin, "swap")
         }),
         "tswap" = commsim(method="tswap", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call("do_swap", as.matrix(x), n, thin, "trialswap",
-                  PACKAGE = "vegan")
+            .Call(do_swap, as.matrix(x), n, thin, "trialswap")
         }),
         "curveball" = commsim(method="curveball", binary = TRUE, isSeq=TRUE,
         mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call("do_curveball", as.matrix(x), n, thin, PACKAGE = "vegan")
+            .Call(do_curveball, as.matrix(x), n, thin)
         }),
         "backtrack" = commsim(method="backtrack", binary=TRUE, isSeq=FALSE,
         mode="integer",
@@ -161,8 +159,7 @@ function(method)
         "swap_count" = commsim(method="swap_count", binary = FALSE,
         isSeq=TRUE, mode = "integer",
         fun = function(x, n, nr, nc, rs, cs, rf, cf, s, fill, thin) {
-            .Call("do_swap", as.matrix(x), n, thin, "swapcount",
-                  PACKAGE = "vegan")
+            .Call(do_swap, as.matrix(x), n, thin, "swapcount")
         }),
         "quasiswap_count" = commsim(method="quasiswap_count", binary=FALSE,
         isSeq=FALSE, mode="integer",
@@ -171,7 +168,7 @@ function(method)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(n, rs, cs)), c(nr, nc, n))
             storage.mode(out) <- "integer"
-            .Call("do_qswap", out, n, fill, "rswapcount", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, fill, "rswapcount")
         }),
         "swsh_samp" = commsim(method="swsh_samp", binary=FALSE, isSeq=FALSE,
         mode="double",
@@ -181,7 +178,7 @@ function(method)
             nz <- x[x > 0]
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
             ## do_qswap changes 'out' within the function
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             for (k in seq_len(n)) {
                 out[,,k][out[,,k] > 0] <- sample(nz) # we assume that length(nz)>1
@@ -198,7 +195,7 @@ function(method)
             }
             nz <- as.integer(x[x > 0])
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 out[,,k][out[,,k] > 0] <- indshuffle(nz - 1L) + 1L  # we assume that length(nz)>1
@@ -211,7 +208,7 @@ function(method)
             if (nr < 2L || nc < 2)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             I <- seq_len(nr)
             for (k in seq_len(n)) {
@@ -231,7 +228,7 @@ function(method)
             if (nr < 2L || nc < 2)
                 stop("needs at least 2 items")
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "double"
             J <- seq_len(nc)
             for (k in seq_len(n)) {
@@ -255,7 +252,7 @@ function(method)
             }
             I <- seq_len(nr)
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 for (i in I) {
@@ -278,7 +275,7 @@ function(method)
             }
             J <- seq_len(nc)
             out <- array(unlist(r2dtable(fill, rf, cf)), c(nr, nc, n))
-            .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+            .Call(do_qswap, out, n, thin, "quasiswap")
             storage.mode(out) <- "integer"
             for (k in seq_len(n)) {
                 for (j in J) {
@@ -294,12 +291,12 @@ function(method)
         "abuswap_r" = commsim(method="abuswap_r", binary=FALSE, isSeq=TRUE,
         mode="double",
         fun=function(x, n, nr, nc, cs, rs, rf, cf, s, fill, thin) {
-            .Call("do_abuswap", as.matrix(x), n, thin, 1L, PACKAGE = "vegan")
+            .Call(do_abuswap, as.matrix(x), n, thin, 1L)
         }),
         "abuswap_c" = commsim(method="abuswap_c", binary=FALSE, isSeq=TRUE,
         mode="double",
         fun=function(x, n, nr, nc, cs, rs, rf, cf, s, fill, thin) {
-            .Call("do_abuswap", as.matrix(x), n, thin, 0L, PACKAGE = "vegan")
+            .Call(do_abuswap, as.matrix(x), n, thin, 0L)
         }),
         "r00_samp" = commsim(method="r00_samp", binary=FALSE, isSeq=FALSE,
         mode="double",

--- a/R/monoMDS.R
+++ b/R/monoMDS.R
@@ -104,7 +104,8 @@
         ities <- 1
     else
         ities <- 2
-    ## Fortran call
+    ## Fortran call -- must quoted because monoMDS has mixed case (or
+    ## can be FIXED)
     sol <- .Fortran("monoMDS", nobj = as.integer(nobj), nfix=as.integer(0),
                  ndim = as.integer(k), ndis = as.integer(ndis),
                  ngrp = as.integer(ngrp), diss = as.double(dist),

--- a/R/monoMDS.R
+++ b/R/monoMDS.R
@@ -3,7 +3,7 @@
              model = c("global", "local", "linear", "hybrid"),
              threshold = 0.8, maxit = 200, weakties = TRUE, stress = 1,
              scaling = TRUE, pc = TRUE, smin = 1e-4, sfgrmin = 1e-7,
-             sratmax=0.99999, ...) 
+             sratmax=0.99999, ...)
 {
     ## Check that 'dist' are distances or a symmetric square matrix
     if (!(inherits(dist, "dist") ||
@@ -117,8 +117,7 @@
                  sfgrmn = as.double(sfgrmin), dist = double(ndis),
                  dhat = double(ndis), points = double(k*nobj),
                  stress = double(1), grstress = double(ngrp),
-                 iters = integer(1), icause = integer(1),
-                 PACKAGE = "vegan")
+                 iters = integer(1), icause = integer(1))
     sol$call <- match.call()
     sol$model <- model
     sol$points <- matrix(sol$points, nobj, k)

--- a/R/no.shared.R
+++ b/R/no.shared.R
@@ -2,7 +2,7 @@
     function(x)
 {
     x <- as.matrix(x)
-    d <- .Call("do_vegdist", x, as.integer(99), PACKAGE = "vegan")
+    d <- .Call(do_vegdist, x, as.integer(99))
     d <- as.logical(d)
     attr(d, "Size") <- NROW(x)
     attr(d, "Labels") <- dimnames(x)[[1]]

--- a/R/no.shared.R
+++ b/R/no.shared.R
@@ -2,7 +2,7 @@
     function(x)
 {
     x <- as.matrix(x)
-    d <- .Call(veg_do_vegdist, x, as.integer(99))
+    d <- .Call(do_vegdist, x, as.integer(99))
     d <- as.logical(d)
     attr(d, "Size") <- NROW(x)
     attr(d, "Labels") <- dimnames(x)[[1]]

--- a/R/no.shared.R
+++ b/R/no.shared.R
@@ -2,7 +2,7 @@
     function(x)
 {
     x <- as.matrix(x)
-    d <- .Call(do_vegdist, x, as.integer(99))
+    d <- .Call(veg_do_vegdist, x, as.integer(99))
     d <- as.logical(d)
     attr(d, "Size") <- NROW(x)
     attr(d, "Labels") <- dimnames(x)[[1]]

--- a/R/orderingKM.R
+++ b/R/orderingKM.R
@@ -26,11 +26,11 @@
 
     scores<-rep(0.0,nb.obj)
     if (USEPOWERALGORITHM) {
-	scores <- as.vector(.Fortran(veg_orderdata, as.integer(mat),
+	scores <- as.vector(.Fortran(orderdata, as.integer(mat),
                                    as.integer(nb.obj), as.integer(nb.desc),
                                    sc=as.double(scores))$sc)
     } else {
-        d <- .Call(veg_do_vegdist, as.matrix(mat), as.integer(50))
+        d <- .Call(do_vegdist, as.matrix(mat), as.integer(50))
         attr(d, "Size") <- nb.obj
         attr(d, "Labels") <- dimnames(mat)[[1]]
         attr(d, "Diag") <- FALSE

--- a/R/orderingKM.R
+++ b/R/orderingKM.R
@@ -26,13 +26,11 @@
 
     scores<-rep(0.0,nb.obj)
     if (USEPOWERALGORITHM) {
-	scores<-as.vector(.Fortran("orderdata",as.integer(mat),
+	scores <- as.vector(.Fortran(orderdata, as.integer(mat),
                                    as.integer(nb.obj), as.integer(nb.desc),
-                                   sc=as.double(scores),
-                                   PACKAGE="vegan")$sc)
+                                   sc=as.double(scores))$sc)
     } else {
-        d <- .Call("do_vegdist", as.matrix(mat), as.integer(50),
-                   PACKAGE = "vegan")
+        d <- .Call(do_vegdist, as.matrix(mat), as.integer(50))
         attr(d, "Size") <- nb.obj
         attr(d, "Labels") <- dimnames(mat)[[1]]
         attr(d, "Diag") <- FALSE

--- a/R/orderingKM.R
+++ b/R/orderingKM.R
@@ -26,11 +26,11 @@
 
     scores<-rep(0.0,nb.obj)
     if (USEPOWERALGORITHM) {
-	scores <- as.vector(.Fortran(orderdata, as.integer(mat),
+	scores <- as.vector(.Fortran(veg_orderdata, as.integer(mat),
                                    as.integer(nb.obj), as.integer(nb.desc),
                                    sc=as.double(scores))$sc)
     } else {
-        d <- .Call(do_vegdist, as.matrix(mat), as.integer(50))
+        d <- .Call(veg_do_vegdist, as.matrix(mat), as.integer(50))
         attr(d, "Size") <- nb.obj
         attr(d, "Labels") <- dimnames(mat)[[1]]
         attr(d, "Diag") <- FALSE

--- a/R/ordisurf.R
+++ b/R/ordisurf.R
@@ -130,7 +130,7 @@
     npol <- length(poly)
     np <- nrow(newd)
     inpoly <- numeric(np)
-    inpoly <- .C(veg_pnpoly, as.integer(npol), as.double(xhull1),
+    inpoly <- .C(pnpoly, as.integer(npol), as.double(xhull1),
                  as.double(xhull2), as.integer(np), as.double(newd[,1]),
                  as.double(newd[,2]), inpoly = as.integer(inpoly))$inpoly
     is.na(fit) <- inpoly == 0

--- a/R/ordisurf.R
+++ b/R/ordisurf.R
@@ -130,7 +130,7 @@
     npol <- length(poly)
     np <- nrow(newd)
     inpoly <- numeric(np)
-    inpoly <- .C(pnpoly, as.integer(npol), as.double(xhull1),
+    inpoly <- .C(veg_pnpoly, as.integer(npol), as.double(xhull1),
                  as.double(xhull2), as.integer(np), as.double(newd[,1]),
                  as.double(newd[,2]), inpoly = as.integer(inpoly))$inpoly
     is.na(fit) <- inpoly == 0

--- a/R/ordisurf.R
+++ b/R/ordisurf.R
@@ -130,10 +130,9 @@
     npol <- length(poly)
     np <- nrow(newd)
     inpoly <- numeric(np)
-    inpoly <- .C("pnpoly", as.integer(npol), as.double(xhull1),
+    inpoly <- .C(pnpoly, as.integer(npol), as.double(xhull1),
                  as.double(xhull2), as.integer(np), as.double(newd[,1]),
-                 as.double(newd[,2]), inpoly = as.integer(inpoly),
-                 PACKAGE="vegan")$inpoly
+                 as.double(newd[,2]), inpoly = as.integer(inpoly))$inpoly
     is.na(fit) <- inpoly == 0
     if(plot) {
         if (!add) {

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -38,7 +38,7 @@ permutest.default <- function(x, ...)
     {
         if (!is.matrix(indx))
             indx <- matrix(indx, nrow=1)
-        out <- .Call(veg_do_getF, indx, E, Q, QZ, effects, first, isPartial, isDB)
+        out <- .Call("do_getF", indx, E, Q, QZ, effects, first, isPartial, isDB)
         p <- length(effects)
         if (!isPartial && !first)
             out[,p+1] <- Chi.tot - rowSums(out[,seq_len(p), drop=FALSE])

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -38,7 +38,7 @@ permutest.default <- function(x, ...)
     {
         if (!is.matrix(indx))
             indx <- matrix(indx, nrow=1)
-        out <- .Call("do_getF", indx, E, Q, QZ, effects, first, isPartial, isDB)
+        out <- .Call(do_getF, indx, E, Q, QZ, effects, first, isPartial, isDB)
         p <- length(effects)
         if (!isPartial && !first)
             out[,p+1] <- Chi.tot - rowSums(out[,seq_len(p), drop=FALSE])

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -38,7 +38,7 @@ permutest.default <- function(x, ...)
     {
         if (!is.matrix(indx))
             indx <- matrix(indx, nrow=1)
-        out <- .Call("do_getF", indx, E, Q, QZ, effects, first, isPartial, isDB)
+        out <- .Call(veg_do_getF, indx, E, Q, QZ, effects, first, isPartial, isDB)
         p <- length(effects)
         if (!isPartial && !first)
             out[,p+1] <- Chi.tot - rowSums(out[,seq_len(p), drop=FALSE])

--- a/R/read.cep.R
+++ b/R/read.cep.R
@@ -14,8 +14,8 @@
   if (file.access(file, 4) < 0) {
     stop("file does not exist or is not readable")
   }
-  on.exit(.Fortran(veg_cepclose))
-  cep <- .Fortran(veg_cephead, file = file, kind = integer(1),
+  on.exit(.Fortran(cepclose))
+  cep <- .Fortran(cephead, file = file, kind = integer(1),
                   nitem = integer(1), nst = integer(1), fmt = character(1))
   if (cep$kind > 3)
     stop("Unknown CEP file type")
@@ -27,7 +27,7 @@
     cat(".\n")
   }
   switch(cep$kind,
-         cd <- .Fortran(veg_cepfree,
+         cd <- .Fortran(cepfree,
                         nitem = as.integer(cep$nitem),
                         axdat = as.integer(maxdata),
                         nsp = integer(1),
@@ -37,7 +37,7 @@
                         y = double(maxdata),
                         w = double(cep$nitem),
                         ier = integer(1)),
-         cd <- .Fortran(veg_cepopen,
+         cd <- .Fortran(cepopen,
                         fmt = as.character(cep$fmt),
                         nitem = as.integer(cep$nitem),
                         maxdat = as.integer(maxdata),
@@ -48,7 +48,7 @@
                         y = double(maxdata),
                         w = double(cep$nitem),
                         ier = integer(1)),
-         cd <- .Fortran(veg_cepcond,
+         cd <- .Fortran(cepcond,
                         fmt = as.character(cep$fmt),
                         nitem = as.integer(cep$nitem),
                         maxdat = as.integer(maxdata),
@@ -72,7 +72,7 @@
   nlines <- ceiling(cd$nsp/10)
   names <- NULL
   for (i in seq_len(nlines)) {
-    tmpnames <- .Fortran(veg_cepnames, character(1))
+    tmpnames <- .Fortran(cepnames, character(1))
     tmpnames <- substring(as.character(tmpnames), 1, 80)
     tmpnames <- substring(tmpnames, seq(1, 80, by = 8), seq(8,
                                                  80, by = 8))
@@ -84,7 +84,7 @@
   nlines <- ceiling(cd$nst/10)
   names <- NULL
   for (i in seq_len(nlines)) {
-    tmpnames <- .Fortran(veg_cepnames, character(1))
+    tmpnames <- .Fortran(cepnames, character(1))
     tmpnames <- substring(as.character(tmpnames), 1, 80)
     tmpnames <- substring(tmpnames, seq(1, 80, by = 8), seq(8,
                                                  80, by = 8))

--- a/R/read.cep.R
+++ b/R/read.cep.R
@@ -1,4 +1,4 @@
-"read.cep" <-
+`read.cep` <-
   function (file, maxdata = 10000, positive = TRUE, trace = FALSE,
             force = FALSE)
 {
@@ -14,10 +14,9 @@
   if (file.access(file, 4) < 0) {
     stop("file does not exist or is not readable")
   }
-  on.exit(.Fortran("cepclose", PACKAGE = "vegan"))
-  cep <- .Fortran("cephead", file = file, kind = integer(1),
-                  nitem = integer(1), nst = integer(1), fmt = character(1),
-                  PACKAGE = "vegan")
+  on.exit(.Fortran(cepclose))
+  cep <- .Fortran(cephead, file = file, kind = integer(1),
+                  nitem = integer(1), nst = integer(1), fmt = character(1))
   if (cep$kind > 3)
     stop("Unknown CEP file type")
   if (trace) {
@@ -28,7 +27,7 @@
     cat(".\n")
   }
   switch(cep$kind,
-         cd <- .Fortran("cepfree",
+         cd <- .Fortran(cepfree,
                         nitem = as.integer(cep$nitem),
                         axdat = as.integer(maxdata),
                         nsp = integer(1),
@@ -37,9 +36,8 @@
                         j = integer(maxdata),
                         y = double(maxdata),
                         w = double(cep$nitem),
-                        ier = integer(1),
-                        PACKAGE = "vegan"),
-         cd <- .Fortran("cepopen",
+                        ier = integer(1)),
+         cd <- .Fortran(cepopen,
                         fmt = as.character(cep$fmt),
                         nitem = as.integer(cep$nitem),
                         maxdat = as.integer(maxdata),
@@ -49,9 +47,8 @@
                         j = integer(maxdata),
                         y = double(maxdata),
                         w = double(cep$nitem),
-                        ier = integer(1),
-                        PACKAGE = "vegan"),
-         cd <- .Fortran("cepcond",
+                        ier = integer(1)),
+         cd <- .Fortran(cepcond,
                         fmt = as.character(cep$fmt),
                         nitem = as.integer(cep$nitem),
                         maxdat = as.integer(maxdata),
@@ -62,8 +59,7 @@
                         y = double(maxdata),
                         w = double(cep$nitem),
                         iw = integer(cep$nitem),
-                        ier = integer(1),
-                        PACKAGE = "vegan"))
+                        ier = integer(1)))
   if (cd$ier) {
     if (cd$ier == 1)
       stop("too many non-zero entries: increase maxdata")
@@ -76,7 +72,7 @@
   nlines <- ceiling(cd$nsp/10)
   names <- NULL
   for (i in seq_len(nlines)) {
-    tmpnames <- .Fortran("cepnames", character(1), PACKAGE = "vegan")
+    tmpnames <- .Fortran(cepnames, character(1))
     tmpnames <- substring(as.character(tmpnames), 1, 80)
     tmpnames <- substring(tmpnames, seq(1, 80, by = 8), seq(8,
                                                  80, by = 8))
@@ -88,7 +84,7 @@
   nlines <- ceiling(cd$nst/10)
   names <- NULL
   for (i in seq_len(nlines)) {
-    tmpnames <- .Fortran("cepnames", character(1), PACKAGE = "vegan")
+    tmpnames <- .Fortran(cepnames, character(1))
     tmpnames <- substring(as.character(tmpnames), 1, 80)
     tmpnames <- substring(tmpnames, seq(1, 80, by = 8), seq(8,
                                                  80, by = 8))

--- a/R/read.cep.R
+++ b/R/read.cep.R
@@ -14,8 +14,8 @@
   if (file.access(file, 4) < 0) {
     stop("file does not exist or is not readable")
   }
-  on.exit(.Fortran(cepclose))
-  cep <- .Fortran(cephead, file = file, kind = integer(1),
+  on.exit(.Fortran(veg_cepclose))
+  cep <- .Fortran(veg_cephead, file = file, kind = integer(1),
                   nitem = integer(1), nst = integer(1), fmt = character(1))
   if (cep$kind > 3)
     stop("Unknown CEP file type")
@@ -27,7 +27,7 @@
     cat(".\n")
   }
   switch(cep$kind,
-         cd <- .Fortran(cepfree,
+         cd <- .Fortran(veg_cepfree,
                         nitem = as.integer(cep$nitem),
                         axdat = as.integer(maxdata),
                         nsp = integer(1),
@@ -37,7 +37,7 @@
                         y = double(maxdata),
                         w = double(cep$nitem),
                         ier = integer(1)),
-         cd <- .Fortran(cepopen,
+         cd <- .Fortran(veg_cepopen,
                         fmt = as.character(cep$fmt),
                         nitem = as.integer(cep$nitem),
                         maxdat = as.integer(maxdata),
@@ -48,7 +48,7 @@
                         y = double(maxdata),
                         w = double(cep$nitem),
                         ier = integer(1)),
-         cd <- .Fortran(cepcond,
+         cd <- .Fortran(veg_cepcond,
                         fmt = as.character(cep$fmt),
                         nitem = as.integer(cep$nitem),
                         maxdat = as.integer(maxdata),
@@ -72,7 +72,7 @@
   nlines <- ceiling(cd$nsp/10)
   names <- NULL
   for (i in seq_len(nlines)) {
-    tmpnames <- .Fortran(cepnames, character(1))
+    tmpnames <- .Fortran(veg_cepnames, character(1))
     tmpnames <- substring(as.character(tmpnames), 1, 80)
     tmpnames <- substring(tmpnames, seq(1, 80, by = 8), seq(8,
                                                  80, by = 8))
@@ -84,7 +84,7 @@
   nlines <- ceiling(cd$nst/10)
   names <- NULL
   for (i in seq_len(nlines)) {
-    tmpnames <- .Fortran(cepnames, character(1))
+    tmpnames <- .Fortran(veg_cepnames, character(1))
     tmpnames <- substring(as.character(tmpnames), 1, 80)
     tmpnames <- substring(tmpnames, seq(1, 80, by = 8), seq(8,
                                                  80, by = 8))

--- a/R/spantree.R
+++ b/R/spantree.R
@@ -1,12 +1,12 @@
 `spantree` <-
-    function (d, toolong = 0) 
+    function (d, toolong = 0)
 {
     dis <- as.dist(d)
     n <- attr(dis, "Size")
     labels <- labels(dis)
-    dis <- .C("primtree", dist = as.double(dis), toolong = as.double(toolong), 
+    dis <- .C(primtree, dist = as.double(dis), toolong = as.double(toolong),
               n = as.integer(n), val = double(n + 1),
-              dad = integer(n + 1), NAOK = TRUE, PACKAGE = "vegan")
+              dad = integer(n + 1), NAOK = TRUE)
     out <- list(kid = dis$dad[2:n] + 1, dist = dis$val[2:n],
                 labels = labels, n = n, call = match.call())
     class(out) <- "spantree"

--- a/R/spantree.R
+++ b/R/spantree.R
@@ -4,7 +4,7 @@
     dis <- as.dist(d)
     n <- attr(dis, "Size")
     labels <- labels(dis)
-    dis <- .C(primtree, dist = as.double(dis), toolong = as.double(toolong),
+    dis <- .C(veg_primtree, dist = as.double(dis), toolong = as.double(toolong),
               n = as.integer(n), val = double(n + 1),
               dad = integer(n + 1), NAOK = TRUE)
     out <- list(kid = dis$dad[2:n] + 1, dist = dis$val[2:n],

--- a/R/spantree.R
+++ b/R/spantree.R
@@ -4,7 +4,7 @@
     dis <- as.dist(d)
     n <- attr(dis, "Size")
     labels <- labels(dis)
-    dis <- .C(veg_primtree, dist = as.double(dis), toolong = as.double(toolong),
+    dis <- .C(primtree, dist = as.double(dis), toolong = as.double(toolong),
               n = as.integer(n), val = double(n + 1),
               dad = integer(n + 1), NAOK = TRUE)
     out <- list(kid = dis$dad[2:n] + 1, dist = dis$val[2:n],

--- a/R/stepacross.R
+++ b/R/stepacross.R
@@ -1,17 +1,17 @@
-"stepacross" <-
-    function (dis, path = "shortest", toolong = 1, trace = TRUE, ...) 
+`stepacross` <-
+    function (dis, path = "shortest", toolong = 1, trace = TRUE, ...)
 {
     path <- match.arg(path, c("shortest", "extended"))
-    if (!inherits(dis, "dist")) 
+    if (!inherits(dis, "dist"))
         dis <- as.dist(dis)
     oldatt <- attributes(dis)
     n <- attr(dis, "Size")
-    if (path == "shortest") 
-        dis <- .C("dykstrapath", dist = as.double(dis), n = as.integer(n), 
-                  as.double(toolong), as.integer(trace), out = double(length(dis)), 
-                  NAOK = TRUE, PACKAGE = "vegan")$out
-    else dis <- .C("stepacross", dis = as.double(dis), as.integer(n), 
-                   as.double(toolong), as.integer(trace), NAOK = TRUE, PACKAGE = "vegan")$dis
+    if (path == "shortest")
+        dis <- .C(dykstrapath, dist = as.double(dis), n = as.integer(n),
+                  as.double(toolong), as.integer(trace),
+                  out = double(length(dis)), NAOK = TRUE)$out
+    else dis <- .C(C_stepacross, dis = as.double(dis), as.integer(n),
+                   as.double(toolong), as.integer(trace), NAOK = TRUE)$dis
     attributes(dis) <- oldatt
     attr(dis, "method") <- paste(attr(dis, "method"), path)
     dis

--- a/R/stepacross.R
+++ b/R/stepacross.R
@@ -7,10 +7,10 @@
     oldatt <- attributes(dis)
     n <- attr(dis, "Size")
     if (path == "shortest")
-        dis <- .C(dykstrapath, dist = as.double(dis), n = as.integer(n),
+        dis <- .C(veg_dykstrapath, dist = as.double(dis), n = as.integer(n),
                   as.double(toolong), as.integer(trace),
                   out = double(length(dis)), NAOK = TRUE)$out
-    else dis <- .C(C_stepacross, dis = as.double(dis), as.integer(n),
+    else dis <- .C(veg_C_stepacross, dis = as.double(dis), as.integer(n),
                    as.double(toolong), as.integer(trace), NAOK = TRUE)$dis
     attributes(dis) <- oldatt
     attr(dis, "method") <- paste(attr(dis, "method"), path)

--- a/R/stepacross.R
+++ b/R/stepacross.R
@@ -7,10 +7,10 @@
     oldatt <- attributes(dis)
     n <- attr(dis, "Size")
     if (path == "shortest")
-        dis <- .C(veg_dykstrapath, dist = as.double(dis), n = as.integer(n),
+        dis <- .C(dykstrapath, dist = as.double(dis), n = as.integer(n),
                   as.double(toolong), as.integer(trace),
                   out = double(length(dis)), NAOK = TRUE)$out
-    else dis <- .C(veg_C_stepacross, dis = as.double(dis), as.integer(n),
+    else dis <- .C(C_stepacross, dis = as.double(dis), as.integer(n),
                    as.double(toolong), as.integer(trace), NAOK = TRUE)$dis
     attributes(dis) <- oldatt
     attr(dis, "method") <- paste(attr(dis, "method"), path)

--- a/R/vectorfit.R
+++ b/R/vectorfit.R
@@ -6,9 +6,9 @@
         w <- 1
     if (length(w) == 1)
         w <- rep(w, nrow(X))
-    Xw <- .Call(veg_do_wcentre, X, w)
+    Xw <- .Call(do_wcentre, X, w)
     P <- as.matrix(P)
-    Pw <- .Call(veg_do_wcentre, P, w)
+    Pw <- .Call(do_wcentre, P, w)
     colnames(Pw) <- colnames(P)
     nc <- ncol(X)
     Q <- qr(Xw)
@@ -32,7 +32,7 @@
     if (permutations) {
         ptest <- function(indx, ...) {
             take <- P[indx, , drop = FALSE]
-            take <- .Call(veg_do_wcentre, take, w)
+            take <- .Call(do_wcentre, take, w)
             Hperm <- qr.fitted(Q, take)
             diag(cor(Hperm, take))^2
         }

--- a/R/vectorfit.R
+++ b/R/vectorfit.R
@@ -6,9 +6,9 @@
         w <- 1
     if (length(w) == 1)
         w <- rep(w, nrow(X))
-    Xw <- .Call("do_wcentre", X, w, PACKAGE = "vegan")
+    Xw <- .Call(do_wcentre, X, w)
     P <- as.matrix(P)
-    Pw <- .Call("do_wcentre", P, w, PACKAGE = "vegan")
+    Pw <- .Call(do_wcentre, P, w)
     colnames(Pw) <- colnames(P)
     nc <- ncol(X)
     Q <- qr(Xw)
@@ -32,7 +32,7 @@
     if (permutations) {
         ptest <- function(indx, ...) {
             take <- P[indx, , drop = FALSE]
-            take <- .Call("do_wcentre", take, w, PACKAGE = "vegan")
+            take <- .Call(do_wcentre, take, w)
             Hperm <- qr.fitted(Q, take)
             diag(cor(Hperm, take))^2
         }

--- a/R/vectorfit.R
+++ b/R/vectorfit.R
@@ -6,9 +6,9 @@
         w <- 1
     if (length(w) == 1)
         w <- rep(w, nrow(X))
-    Xw <- .Call(do_wcentre, X, w)
+    Xw <- .Call(veg_do_wcentre, X, w)
     P <- as.matrix(P)
-    Pw <- .Call(do_wcentre, P, w)
+    Pw <- .Call(veg_do_wcentre, P, w)
     colnames(Pw) <- colnames(P)
     nc <- ncol(X)
     Q <- qr(Xw)
@@ -32,7 +32,7 @@
     if (permutations) {
         ptest <- function(indx, ...) {
             take <- P[indx, , drop = FALSE]
-            take <- .Call(do_wcentre, take, w)
+            take <- .Call(veg_do_wcentre, take, w)
             Hperm <- qr.fitted(Q, take)
             diag(cor(Hperm, take))^2
         }

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -37,7 +37,7 @@
                                                      as.vector(x)), TRUE))
         warning("results may be meaningless with non-integer data in method ",
                 dQuote(inm))
-    d <- .Call("do_vegdist", as.matrix(x), as.integer(method), PACKAGE = "vegan")
+    d <- .Call(do_vegdist, as.matrix(x), as.integer(method))
     if (method == 10)
         d <- 2 * d/(1 + d)
     d[d < ZAP] <- 0

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -37,7 +37,7 @@
                                                      as.vector(x)), TRUE))
         warning("results may be meaningless with non-integer data in method ",
                 dQuote(inm))
-    d <- .Call(do_vegdist, as.matrix(x), as.integer(method))
+    d <- .Call(veg_do_vegdist, as.matrix(x), as.integer(method))
     if (method == 10)
         d <- 2 * d/(1 + d)
     d[d < ZAP] <- 0

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -37,7 +37,7 @@
                                                      as.vector(x)), TRUE))
         warning("results may be meaningless with non-integer data in method ",
                 dQuote(inm))
-    d <- .Call(veg_do_vegdist, as.matrix(x), as.integer(method))
+    d <- .Call(do_vegdist, as.matrix(x), as.integer(method))
     if (method == 10)
         d <- 2 * d/(1 + d)
     d[d < ZAP] <- 0

--- a/src/init.c
+++ b/src/init.c
@@ -8,11 +8,11 @@
 */
 
 /* .C calls */
+extern void C_stepacross(void *, void *, void *, void *);
 extern void dykstrapath(void *, void *, void *, void *, void *);
 extern void pnpoly(void *, void *, void *, void *, void *, void *, void *);
 extern void primtree(void *, void *, void *, void *, void *);
 extern void stepabyss(void *, void *, void *, void *);
-extern void stepacross(void *, void *, void *, void *);
 
 /* .Call calls */
 extern SEXP do_abuswap(SEXP, SEXP, SEXP, SEXP);
@@ -38,11 +38,11 @@ extern void F77_NAME(monomds)(void *, void *, void *, void *, void *, void *, vo
 extern void F77_NAME(orderdata)(void *, void *, void *, void *);
 
 static const R_CMethodDef CEntries[] = {
-    {"dykstrapath", (DL_FUNC) &dykstrapath, 5},
-    {"pnpoly",      (DL_FUNC) &pnpoly,      7},
-    {"primtree",    (DL_FUNC) &primtree,    5},
-    {"stepabyss",   (DL_FUNC) &stepabyss,   4},
-    {"stepacross",  (DL_FUNC) &stepacross,  4},
+    {"C_stepacross", (DL_FUNC) &C_stepacross, 4},
+    {"dykstrapath",  (DL_FUNC) &dykstrapath,  5},
+    {"pnpoly",       (DL_FUNC) &pnpoly,       7},
+    {"primtree",     (DL_FUNC) &primtree,     5},
+    {"stepabyss",    (DL_FUNC) &stepabyss,    4},
     {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,80 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
+
+/* FIXME: 
+   Check these declarations against the C/Fortran source code.
+*/
+
+/* .C calls */
+extern void dykstrapath(void *, void *, void *, void *, void *);
+extern void pnpoly(void *, void *, void *, void *, void *, void *, void *);
+extern void primtree(void *, void *, void *, void *, void *);
+extern void stepabyss(void *, void *, void *, void *);
+extern void stepacross(void *, void *, void *, void *);
+
+/* .Call calls */
+extern SEXP do_abuswap(SEXP, SEXP, SEXP, SEXP);
+extern SEXP do_chaoterms(SEXP);
+extern SEXP do_curveball(SEXP, SEXP, SEXP);
+extern SEXP do_decorana(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP do_getF(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP do_goffactor(SEXP, SEXP, SEXP, SEXP);
+extern SEXP do_minterms(SEXP);
+extern SEXP do_qswap(SEXP, SEXP, SEXP, SEXP);
+extern SEXP do_swap(SEXP, SEXP, SEXP, SEXP);
+extern SEXP do_vegdist(SEXP, SEXP);
+extern SEXP do_wcentre(SEXP, SEXP);
+
+/* .Fortran calls */
+extern void F77_NAME(cepclose)();
+extern void F77_NAME(cepcond)(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void F77_NAME(cepfree)(void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void F77_NAME(cephead)(void *, void *, void *, void *, void *);
+extern void F77_NAME(cepnames)(void *);
+extern void F77_NAME(cepopen)(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void F77_NAME(monomds)(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void F77_NAME(orderdata)(void *, void *, void *, void *);
+
+static const R_CMethodDef CEntries[] = {
+    {"dykstrapath", (DL_FUNC) &dykstrapath, 5},
+    {"pnpoly",      (DL_FUNC) &pnpoly,      7},
+    {"primtree",    (DL_FUNC) &primtree,    5},
+    {"stepabyss",   (DL_FUNC) &stepabyss,   4},
+    {"stepacross",  (DL_FUNC) &stepacross,  4},
+    {NULL, NULL, 0}
+};
+
+static const R_CallMethodDef CallEntries[] = {
+    {"do_abuswap",   (DL_FUNC) &do_abuswap,   4},
+    {"do_chaoterms", (DL_FUNC) &do_chaoterms, 1},
+    {"do_curveball", (DL_FUNC) &do_curveball, 3},
+    {"do_decorana",  (DL_FUNC) &do_decorana,  7},
+    {"do_getF",      (DL_FUNC) &do_getF,      8},
+    {"do_goffactor", (DL_FUNC) &do_goffactor, 4},
+    {"do_minterms",  (DL_FUNC) &do_minterms,  1},
+    {"do_qswap",     (DL_FUNC) &do_qswap,     4},
+    {"do_swap",      (DL_FUNC) &do_swap,      4},
+    {"do_vegdist",   (DL_FUNC) &do_vegdist,   2},
+    {"do_wcentre",   (DL_FUNC) &do_wcentre,   2},
+    {NULL, NULL, 0}
+};
+
+static const R_FortranMethodDef FortranEntries[] = {
+    {"cepclose",  (DL_FUNC) &F77_NAME(cepclose),   0},
+    {"cepcond",   (DL_FUNC) &F77_NAME(cepcond),   11},
+    {"cepfree",   (DL_FUNC) &F77_NAME(cepfree),    9},
+    {"cephead",   (DL_FUNC) &F77_NAME(cephead),    5},
+    {"cepnames",  (DL_FUNC) &F77_NAME(cepnames),   1},
+    {"cepopen",   (DL_FUNC) &F77_NAME(cepopen),   10},
+    {"monomds",   (DL_FUNC) &F77_NAME(monomds),   25},
+    {"orderdata", (DL_FUNC) &F77_NAME(orderdata),  4},
+    {NULL, NULL, 0}
+};
+
+void R_init_vegan(DllInfo *dll)
+{
+    R_registerRoutines(dll, CEntries, CallEntries, FortranEntries, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/stepacross.c
+++ b/src/stepacross.c
@@ -23,7 +23,7 @@
 #define EPS (1e-6)
 #define IND(N,a,b) (N)*(a) - (a)*((a)+1)/2 + (b) - (a) - (1)
 
-void stepacross(double *dist, int *n, double *toolong, int *trace) 
+void C_stepacross(double *dist, int *n, double *toolong, int *trace)
 {
      int i, j, k, nacount, oldcount, ind, ki, kj, inew, *newind, ndist;
      double stepdis, steptry, *newdist, limit;


### PR DESCRIPTION
I have now fully implemented registration of compiled functions ("native code") in **vegan**. This has been mandatory in **CRAN** for some time, and the current release (`2.4-3`) has a minimal implementation to pass the **CRAN** test: a `src/init.c` file that declares the public API. This PR adds the actual registration in `NAMESPACE`. This will change the usage in `.C()`, `.Fortran()` and `.Call()` like this:

```diff
-      .Call("do_qswap", out, n, thin, "quasiswap", PACKAGE = "vegan")
+      .Call(do_qswap, out, n, thin, "quasiswap")
```

This change has little or no advantage to **vegan**, but it can be advantageous to the **R** environment when a huge number of packages are loaded. It is mandatory, though, and we have little choice, except keeping the token implementation that we now have in `2.4-3`. I haven't run any real test on speed, but BRD quotes microsecond speed-ups in R-extensions manual, and that is really little compared to the time we normally spend within the called code. In `R CMD check`, examples and `oecosimu-tests.R` run <5% faster in my Linux desktop and <5% slower in my Mac laptop. The `nullmodel` simulations are now faster than in the release, but there are many other speed-ups, and I haven't analysed the code yet.

From the programmer point of view, the main disadvantage is that the interface is now much more rigid, and developing new compiled code is more tedious, because everything must be registered in `src/init.c`. For instance, the following works without this PR:

```r
 .Call("test_ev", scale(BCI), 1L)
```

This is a non-exported function that I used in debugging the code needed in `permutest.cca`, but with this PR, the `test_ev` function cannot be found.

The crucial piece in registration is the `src/init.c` file that  defines the API to the compiled code. I have now generated this file with `tools::package_native_routine_registration_skeleton()`. This works quite nicely, but only declares compiled functions that are called in **R** functions: as I did not have **R** function to call `test_ev`, it was not exported. Manual maintenance of this file may be tedious and error prone, and personally I would like to avoid this and rely on automated updates.

The registration of compiled functions can lead to new name clashes. Earlier we used text strings of function names, but now we can use unquoted objects. The names of these objects shall not clash with other **R** objects. Earlier **R** function `stepacross` called internally **C** function `stepacross` (as `.C("stepacross", ...)`), but this is no longer possible. Therefore I changed the name of the **C** function (now we have `.C(C_stepacross, ...)`). The `useDynLib()` directive in the `NAMESPACE` allows giving a `.prefix` that is added to the function names so that the names in **R** calls are different from real function names in compiled code. So with `.prefix = "veg_"` we could call **C** function `stepacross` as `.C(veg_stepacross, ...)`  with no conflicts. This could be useful, but unfortunately `tools::package_native_routine_registration_skeleton()` does not know `.prefix` and we have to maintain `src/init.c` manually if we have `.prefix`. I tried this in this PR (commit d494d59), but I reverted this later to retain automatic maintenance of `src/init.c`.
