### PR TITLE
Issue #259

### DIFF
--- a/R/as.preston.R
+++ b/R/as.preston.R
@@ -1,13 +1,17 @@
 `as.preston` <-
-    function (x, tiesplit = TRUE, ...) 
+    function (x, tiesplit = TRUE, ...)
 {
-    if (inherits(x, "preston")) 
+    if (inherits(x, "preston"))
         return(x)
+    ## practically integer
     if (!identical(all.equal(x, round(x)), TRUE))
         stop("function accepts only integers (counts)")
+    ## need exact integers, since, e.g., sqrt(2)^2 - 2 = 4.4e-16 and
+    ## tie breaks fail
+    x <- round(x)
     x <- x[x > 0]
     if (tiesplit) {
-        ## Assume log2(2^k) == k exactly for integer k
+        ## Assume log2(2^k) == k *exactly* for integer k
         xlog2 <- log2(x)
         ties <- xlog2 == ceiling(xlog2)
         tiefreq <- table(xlog2[ties])

--- a/R/estimateR.default.R
+++ b/R/estimateR.default.R
@@ -1,5 +1,5 @@
 `estimateR.default` <-
-    function (x, ...) 
+    function (x, ...)
 {
     gradF <- function(a, i) {
         .expr4 <- sum(i * a)
@@ -17,17 +17,20 @@
         .expr25 <- 1/(1 - sum(i * a)) + a[1]/(1 - sum(i * a))^2
         .expr26 <- .expr7^2
         .expr35 <- .expr16^2
-        Grad <- a[1] * i/(.expr23 * .expr26) * .expr20 + .expr8 * 
-            (1 + a[1] * ((.expr12 + (.expr10 * i * (i - 1)))/.expr16 - 
-                         .expr13 * ((.expr7 * i - (a[1] * i/.expr23) * 
+        Grad <- a[1] * i/(.expr23 * .expr26) * .expr20 + .expr8 *
+            (1 + a[1] * ((.expr12 + (.expr10 * i * (i - 1)))/.expr16 -
+                         .expr13 * ((.expr7 * i - (a[1] * i/.expr23) *
                                      .expr4) * .expr15 + .expr14 * i)/.expr35))
-        Grad[1] <- .expr25/.expr26 * .expr20 + .expr8 * (1 + 
-                                                         (.expr18 + a[1] * (.expr12/.expr16 - .expr13 * ((.expr7 - 
+        Grad[1] <- .expr25/.expr26 * .expr20 + .expr8 * (1 +
+                                                         (.expr18 + a[1] * (.expr12/.expr16 - .expr13 * ((.expr7 -
                                                                                                           .expr25 * .expr4) * .expr15 + .expr14)/.expr35)))
         Grad
     }
-    if (!identical(all.equal(x, round(x)), TRUE)) 
+    ## we need integers
+    if (!identical(all.equal(x, round(x)), TRUE))
         stop("function accepts only integers (counts)")
+    ## and they must be exact
+    x <- round(x)
     X <- x[x > 0]
     N <- sum(X)
     SSC <- 1 # (N-1)/N # do NOT use small-sample correction
@@ -78,10 +81,10 @@
     C.ace <- 1 - a[1]/N.rare
     i <- seq_along(a)
     thing <- i * (i - 1) * a
-    Gam <- sum(thing) * S.rare/(C.ace * N.rare * (N.rare - 1)) - 
+    Gam <- sum(thing) * S.rare/(C.ace * N.rare * (N.rare - 1)) -
         1
     S.ACE <- S.abund + S.rare/C.ace + max(Gam, 0) * a[1]/C.ace
-    sd.ACE <- sqrt(sum(Deriv.Ch1 %*% t(Deriv.Ch1) * (diag(a) - 
+    sd.ACE <- sqrt(sum(Deriv.Ch1 %*% t(Deriv.Ch1) * (diag(a) -
                                                      a %*% t(a)/S.ACE)))
     out <- list(S.obs = S.obs, S.chao1 = S.Chao1, se.chao1 = sd.Chao1,
                 S.ACE = S.ACE, se.ACE = sd.ACE)

--- a/R/rrarefy.R
+++ b/R/rrarefy.R
@@ -6,6 +6,8 @@
     if (!identical(all.equal(x, round(x)), TRUE))
         stop("function is meaningful only for integers (counts)")
     x <- as.matrix(x)
+    ## x may not be exactly integer, since, e.g., sqrt(2)^2 != 2
+    x <- round(x)
     if (ncol(x) == 1)
         x <- t(x)
     if (length(sample) > 1 && length(sample) != nrow(x))

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -34,8 +34,7 @@
     if (binary)
         x <- decostand(x, "pa")
     N <- nrow(x <- as.matrix(x))
-    if (method %in% c(7, 13, 15) && !identical(all.equal(as.integer(x),
-                                                     as.vector(x)), TRUE))
+    if (method %in% c(7, 13, 15) && !identical(all.equal(x, round(x)), TRUE))
         warning("results may be meaningless with non-integer data in method ",
                 dQuote(inm))
     d <- .Call(do_vegdist, as.matrix(x), as.integer(method))


### PR DESCRIPTION
This PR implements soft testing of integer input, and if passed, hard fix to integers with `round()` like I outlined in PR #259. The fix is implemented for `rrarefy`, `as.preston` and `estimateR`  where exact integers were needed because of truncation or breaking ties exactly at the border. This also uses slacker test for `vegdist` methods that use integers, because older truncation invariance was not needed. Other methods can cope with nearly-integer data.