### PR TITLE
Color ordilabel in plot.betadisper function

### DIFF
--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -4,7 +4,7 @@
                               segments = TRUE, seg.col = "grey",
                               seg.lty = lty, seg.lwd = lwd,
                               label = TRUE, label.cex = 1,
-                              ylab, xlab, main, sub, location="bottomright", ...)
+                              ylab, xlab, main, sub, ...)
 {
     localAxis <- function(..., col, bg, pch, cex, lty, lwd) axis(...)
     localBox <- function(..., col, bg, pch, cex, lty, lwd) box(...)
@@ -97,9 +97,6 @@
         # add col
         ordilabel(x, display = "centroids", choices = axes, cex = label.cex, col=col)
     }
-    # add legend
-    legend(location=location, legend=levels(x$group), col=col, lty=1, cex=1.2, pch=pch )
-    
     localTitle(main = main, xlab = xlab, ylab = ylab, sub = sub, ...)
     localAxis(1, ...)
     localAxis(2, ...)

--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -94,8 +94,12 @@
     }
     points(g$sites, pch = pch[x$group], cex = cex, col = col[x$group], ...)
     if (label) {
-        ordilabel(x, display = "centroids", choices = axes, cex = label.cex)
+        # add col
+        ordilabel(x, display = "centroids", choices = axes, cex = label.cex, col=col)
     }
+    # add legend
+    legend("bottomright", legend=levels(x$group), col=col, lty=1, cex=1.2, pch=pch )
+    
     localTitle(main = main, xlab = xlab, ylab = ylab, sub = sub, ...)
     localAxis(1, ...)
     localAxis(2, ...)

--- a/R/plot.betadisper.R
+++ b/R/plot.betadisper.R
@@ -4,7 +4,7 @@
                               segments = TRUE, seg.col = "grey",
                               seg.lty = lty, seg.lwd = lwd,
                               label = TRUE, label.cex = 1,
-                              ylab, xlab, main, sub, ...)
+                              ylab, xlab, main, sub, location="bottomright", ...)
 {
     localAxis <- function(..., col, bg, pch, cex, lty, lwd) axis(...)
     localBox <- function(..., col, bg, pch, cex, lty, lwd) box(...)
@@ -98,7 +98,7 @@
         ordilabel(x, display = "centroids", choices = axes, cex = label.cex, col=col)
     }
     # add legend
-    legend("bottomright", legend=levels(x$group), col=col, lty=1, cex=1.2, pch=pch )
+    legend(location=location, legend=levels(x$group), col=col, lty=1, cex=1.2, pch=pch )
     
     localTitle(main = main, xlab = xlab, ylab = ylab, sub = sub, ...)
     localAxis(1, ...)


### PR DESCRIPTION
color the ordilabel figured below.
![image](https://user-images.githubusercontent.com/1230436/50534649-8bbf5a80-0b7a-11e9-99ec-ec8b694550a8.png)
Updated version for #298
