### PR TITLE
Return average distance to group centre in betadisper

### DIFF
--- a/R/betadisper.R
+++ b/R/betadisper.R
@@ -139,6 +139,8 @@
         n.group <- as.vector(table(group))
         zij <- zij*sqrt(n.group[group]/(n.group[group]-1))
     }
+    ## pre-compute group mean distance to centroid/median for `print` method
+    grp.zij <- tapply(zij, group, "mean")
     ## add in correct labels
     colnames(vectors) <- names(eig) <- paste("PCoA", seq_along(eig), sep = "")
     if(is.matrix(centroids))
@@ -147,7 +149,8 @@
         names(centroids) <- names(eig)
     rownames(vectors) <- names(zij) <- labs
     retval <- list(eig = eig, vectors = vectors, distances = zij,
-                   group = group, centroids = centroids, call = match.call())
+                   group = group, centroids = centroids,
+                   group.distances = grp.zij, call = match.call())
     class(retval) <- "betadisper"
     attr(retval, "method") <- attr(d, "method")
     attr(retval, "type") <- type

--- a/R/print.betadisper.R
+++ b/R/print.betadisper.R
@@ -17,8 +17,7 @@
     type <- ifelse(isTRUE(all.equal(attr(x, "type"), "median")),
                    "median", "centroid")
     writeLines(strwrap(paste0("Average distance to ", type, ":\n")))
-    print.default(format(tapply(x$distances, x$group, mean),
-                         digits = digits), quote = FALSE)
+    print.default(format(x$group.distances, digits = digits), quote = FALSE)
     cat("\n")
     writeLines(strwrap("Eigenvalues for PCoA axes:"))
     if (nev > neigen) {

--- a/man/betadisper.Rd
+++ b/man/betadisper.Rd
@@ -16,10 +16,10 @@
   multivariate homogeneity of group dispersions (variances).
   \code{betadisper} is a multivariate analogue of Levene's test for
   homogeneity of variances. Non-euclidean distances between objects and
-  group centroids are handled by reducing the original distances to
-  principal coordinates. This procedure has latterly been used as a
-  means of assessing beta diversity. There are \code{anova},
-  \code{scores}, \code{plot} and \code{boxplot} methods.
+  group centres (centroids or medians) are handled by reducing the
+  original distances to principal coordinates. This procedure has
+  latterly been used as a means of assessing beta diversity. There are
+  \code{anova}, \code{scores}, \code{plot} and \code{boxplot} methods.
 
   \code{TukeyHSD.betadisper} creates a set of confidence intervals on
   the differences between the mean distance-to-centroid of the levels of
@@ -109,7 +109,9 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE,
   \item{ordered}{logical; see \code{\link{TukeyHSD}}.}
   \item{conf.level}{A numeric value between zero and one giving the
     family-wise confidence level to use.}
-  \item{digits, neigen}{numeric; for the \code{print} method, sets the number of digits to use (as per \code{\link{print.default}}) and the maximum number of axes to display eigenvalues for, repsectively.}
+  \item{digits, neigen}{numeric; for the \code{print} method, sets the
+  number of digits to use (as per \code{\link{print.default}}) and the
+  maximum number of axes to display eigenvalues for, repsectively.}
   \item{\dots}{arguments, including graphical parameters (for
     \code{plot.betadisper} and \code{boxplot.betadisper}), passed to
     other methods.}
@@ -215,10 +217,12 @@ betadisper(d, group, type = c("median","centroid"), bias.adjust = FALSE,
     analysis.}
   \item{distances}{numeric; the Euclidean distances in principal
     coordinate space between the samples and their respective group
-    centroid.}
+    centroid or median.}
   \item{group}{factor; vector describing the group structure}
-  \item{centroids}{matrix; the locations of the group centroids on the
-    principal coordinates.}
+  \item{centroids}{matrix; the locations of the group centroids or
+    medians on the principal coordinates.}
+  \item{group.distances}{numeric; the mean distance to each group
+    centroid or median.}
   \item{call}{the matched function call.}
 }
 \note{


### PR DESCRIPTION
This implements #333  (as discussed in #331).

* Precompute group average distances to centres and return `group.distances` as a new component of the object.
* Modify `print` method and documentation as needed.

My only hesitation is in the choice of name for the component. We now would have `group` and `group.distances` in the object. @jarioksa thoughts?