### PR TITLE
Add names and clean rarecurve objects

### DIFF
--- a/R/rarecurve.R
+++ b/R/rarecurve.R
@@ -30,8 +30,10 @@
         n <- seq(1, tot[i], by = step)
         if (n[length(n)] != tot[i])
             n <- c(n, tot[i])
+        attributes(n) <- NULL
         drop(rarefy(x[i,], n))
     })
+    names(out) <- rownames(x)
     Nmax <- sapply(out, function(x) max(attr(x, "Subsample")))
     Smax <- sapply(out, max)
     ## set up plot
@@ -51,7 +53,7 @@
     }
     ## label curves at their endpoitns
     if (label) {
-        ordilabel(cbind(tot, S), labels=rownames(x), ...)
+        ordilabel(cbind(tot, S), labels = rownames(x), ...)
     }
     invisible(out)
 }


### PR DESCRIPTION
PR to improve the object returned (invisibly) by the rarecurve function. It can be useful for the user to capture it to make custom plot (eg. use ggplot2).

Proposed changes:
- In each element of the list, get rid of the name attribute for Subsample which is meaningless.
- keep track of the site names by setting names to the returned list (i.e. rownames of x).