### PR TITLE
Aitchison distance, clr transformation, and their robust variants

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,3 +15,4 @@ Description: Ordination methods, diversity analysis and other
 License: GPL-2
 BugReports: https://github.com/vegandevs/vegan/issues
 URL: https://github.com/vegandevs/vegan
+RoxygenNote: 7.1.2

--- a/R/decostand.R
+++ b/R/decostand.R
@@ -89,8 +89,8 @@
         if (missing(MARGIN))
 	    MARGIN <- 1
         if (MARGIN == 1) 
-            x <- t(.calc_clr(t(x)))
-	else x <- .calc_clr(x)
+            x <- t(.calc_clr(t(x), ...))
+	else x <- .calc_clr(x, ...)
     }, rclr = {
         if (missing(MARGIN))
 	    MARGIN <- 1
@@ -108,7 +108,10 @@
 
 
 
-.calc_clr <- function(x){
+.calc_clr <- function(x, pseudocount=0){
+    # Add pseudocount
+    x <- x + pseudocount
+    # Calculate relative abundance
     x <- .calc_rel_abund(x)
     # If there is negative values, gives an error.
     if (any(x <= 0, na.rm = TRUE)) {

--- a/R/decostand.R
+++ b/R/decostand.R
@@ -99,7 +99,8 @@
 	else x <- .calc_rclr(x)
     })
     if (any(is.nan(x)))
-        warning("result contains NaN, perhaps due to impossible mathematical operation\n")
+        warning("result contains NaN, perhaps due to impossible mathematical 
+                 operation\n")
     if (wasDataFrame)
         x <- as.data.frame(x)
     attr(x, "decostand") <- method
@@ -145,9 +146,10 @@
    geometric_means_of_samples <- exp(mean_log_x)
    # Divides all values by their sample-wide geometric means
    values_divided_by_geom_mean <- t(x)/geometric_means_of_samples
-   # Does logarithmic transform and transposes the table back to its original form
+   # Does logarithmic transform and transposes the table back to its original
+   # form
    return_x <- t(log(values_divided_by_geom_mean))
-   # If there were zeros, there are infinite values after logarithmic transform. 
+   # If there were zeros, there are infinite values after logarithmic transform.
    # They are converted to zero.
    return_x[is.infinite(return_x)] <- 0
    return_x

--- a/R/decostand.R
+++ b/R/decostand.R
@@ -5,7 +5,7 @@
     x <- as.matrix(x)
     METHODS <- c("total", "max", "frequency", "normalize", "range", "rank",
                  "rrank", "standardize", "pa", "chi.square", "hellinger",
-                 "log", "clr")
+                 "log", "clr", "rclr")
     method <- match.arg(method, METHODS)
     if (any(x < 0, na.rm = na.rm)) {
         k <- min(x, na.rm = na.rm)

--- a/R/decostand.R
+++ b/R/decostand.R
@@ -107,7 +107,7 @@
 }
 
 
-
+# Modified from the original version in mia R package
 .calc_clr <- function(x, pseudocount=0){
     # Add pseudocount
     x <- x + pseudocount
@@ -132,7 +132,7 @@
     return(t(t(clog) - clogm))
 }
 
-
+# Modified from the original version in mia R package
 .calc_rclr <- function(x){
    # Log transform
    log_x <- log(x)
@@ -153,7 +153,7 @@
    return_x
 }
 
-
+# Modified from the original version in mia R package
 # Same as decostand method "total" but faster
 .calc_rel_abund <- function(x){
     sweep(x, 2, colSums(x, na.rm = TRUE), "/")

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -46,10 +46,10 @@
         x <- decostand(x, "normalize")
     if (method == 20) # aitchison
         x <- decostand(x, "clr", ...)  # dots to pass possible pseudocount
-	method == 2 # Aitchison = CLR + Euclid; switch to Euclid now	
+	method <- 2 # Aitchison = CLR + Euclid; switch to Euclid now
     if (method == 21) # aitchison_robust
         x <- decostand(x, "rclr") # No pseudocount for rclr
-	method == 2 # Aitchison = CLR + Euclid; switch to Euclid now	
+	method <- 2 # Aitchison = CLR + Euclid; switch to Euclid now	
     if (binary)
         x <- decostand(x, "pa")
     N <- nrow(x)

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -10,7 +10,8 @@
     METHODS <- c("manhattan", "euclidean", "canberra", "bray", # 4
                  "kulczynski", "gower", "morisita", "horn", #8
                  "mountford", "jaccard", "raup", "binomial", "chao", #13
-                 "altGower", "cao", "mahalanobis", "clark", "chisq", "chord") #19
+                 "altGower", "cao", "mahalanobis", "clark", "chisq", "chord", #19
+		 "aitchison", "aitchison_robust") # 21
     method <- pmatch(method, METHODS)
     inm <- METHODS[method]
     if (is.na(method))
@@ -43,13 +44,21 @@
         x <- decostand(x, "chi.square")
     if (method == 19) # chord
         x <- decostand(x, "normalize")
+    if (method == 20) # aitchison
+        x <- decostand(x, "clr", ...)  # dots to pass possible pseudocount
+    if (method == 21) # aitchison_robust
+        x <- decostand(x, "rclr", ...) # dots to pass possible pseudocount		
     if (binary)
         x <- decostand(x, "pa")
     N <- nrow(x)
     if (method %in% c(7, 13, 15) && !identical(all.equal(x, round(x)), TRUE))
         warning("results may be meaningless with non-integer data in method ",
                 dQuote(inm))
-    d <- .Call(do_vegdist, x, as.integer(method))
+    if (method %in% c(20,21)) { # aitchison and aitchison_robust
+      d <- .Call(do_vegdist, x, 2) # Aitchison = CLR + Euclid
+    } else {
+      d <- .Call(do_vegdist, x, as.integer(method))
+    }
     if (method == 10)
         d <- 2 * d/(1 + d)
     d[d < ZAP] <- 0

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -46,19 +46,17 @@
         x <- decostand(x, "normalize")
     if (method == 20) # aitchison
         x <- decostand(x, "clr", ...)  # dots to pass possible pseudocount
+	method == 2 # Aitchison = CLR + Euclid; switch to Euclid now	
     if (method == 21) # aitchison_robust
-        x <- decostand(x, "rclr", ...) # dots to pass possible pseudocount		
+        x <- decostand(x, "rclr") # No pseudocount for rclr
+	method == 2 # Aitchison = CLR + Euclid; switch to Euclid now	
     if (binary)
         x <- decostand(x, "pa")
     N <- nrow(x)
     if (method %in% c(7, 13, 15) && !identical(all.equal(x, round(x)), TRUE))
         warning("results may be meaningless with non-integer data in method ",
                 dQuote(inm))
-    if (method %in% c(20,21)) { # aitchison and aitchison_robust
-      d <- .Call(do_vegdist, x, 2) # Aitchison = CLR + Euclid
-    } else {
-      d <- .Call(do_vegdist, x, as.integer(method))
-    }
+    d <- .Call(do_vegdist, x, as.integer(method))    
     if (method == 10)
         d <- 2 * d/(1 + d)
     d[d < ZAP] <- 0

--- a/R/vegdist.R
+++ b/R/vegdist.R
@@ -27,14 +27,17 @@
     if (!(is.numeric(x) || is.logical(x)))
         stop("input data must be numeric")
     if (!method %in% c(1,2,6,16,18) && any(rowSums(x, na.rm = TRUE) == 0))
-        warning("you have empty rows: their dissimilarities may be meaningless in method ",
-                dQuote(inm))
+        warning("you have empty rows: their dissimilarities may be 
+                 meaningless in method ",
+                 dQuote(inm))
     ## 1 manhattan, 2 euclidean, 3 canberra, 6 gower, 16 mahalanobis, 19 chord
     if (!method %in% c(1,2,3,6,16,19) && any(x < 0, na.rm = TRUE))
-        warning("results may be meaningless because data have negative entries in method ",
-                dQuote(inm))
+        warning("results may be meaningless because data have negative entries 
+                 in method ",
+                 dQuote(inm))
     if (method %in% c(11,18) && any(colSums(x) == 0))
-        warning("data have empty species which influence the results in method ",
+        warning("data have empty species which influence the results in 
+                 method ",
                 dQuote(inm))
     if (method == 6) # gower, but no altGower
         x <- decostand(x, "range", 2, na.rm = TRUE, ...)
@@ -44,12 +47,14 @@
         x <- decostand(x, "chi.square")
     if (method == 19) # chord
         x <- decostand(x, "normalize")
-    if (method == 20) # aitchison
+    if (method == 20) { # aitchison
         x <- decostand(x, "clr", ...)  # dots to pass possible pseudocount
 	method <- 2 # Aitchison = CLR + Euclid; switch to Euclid now
-    if (method == 21) # aitchison_robust
+    }
+    if (method == 21) { # aitchison_robust
         x <- decostand(x, "rclr") # No pseudocount for rclr
-	method <- 2 # Aitchison = CLR + Euclid; switch to Euclid now	
+	method <- 2 # Aitchison = CLR + Euclid; switch to Euclid now
+    }	
     if (binary)
         x <- decostand(x, "pa")
     N <- nrow(x)

--- a/man/decostand.Rd
+++ b/man/decostand.Rd
@@ -76,7 +76,8 @@ wisconsin(x)
      where \eqn{x_{r}} is a single relative value, g(x_{r}) is the geometric mean
      of relative values per sample, and \eqn{\mu_{r}} is the arithmetic mean of 
      relative values per sample. The method can operate only with positive data; a common
-     way to deal with zeroes is to add pseudocount. 
+     way to deal with zeroes is to add pseudocount.
+     
   }
   Standardization, as contrasted to transformation, means that the
   entries are transformed relative to other entries.

--- a/man/decostand.Rd
+++ b/man/decostand.Rd
@@ -79,10 +79,16 @@ wisconsin(x)
      the geometric mean
      of relative values per sample, and \eqn{\mu_{r}} is the arithmetic mean of 
      relative values per sample. The method can operate only with positive data;
-     a common way to deal with zeroes is to add pseudocount.
+     a common way to deal with zeroes is to add pseudocount, either by
+     adding it manually to the input data, or by using the argument
+     \code{pseudocount} as in
+     \code{vegan::decostand(x, method="clr", pseudocount=1)}. Adding
+     pseudocount will inevitably introduce some bias in the data; see
+     the \code{rclr} method for one available solution.
 
      \item \code{rclr}: robust clr ("rclr") is similar to regular clr
-     (see above) but allows data that contains zeroes.
+     (see above) but allows data that contains zeroes. This method
+     does not use pseudocounts, unlike the standard clr.
      Robust clr divides the values by geometric mean
      of the observed features; zero values are kept as zeroes, and not
      taken into account. In high dimensional data,
@@ -156,7 +162,7 @@ apply(sptrans, 2, max)
 sptrans <- wisconsin(varespec)
 
 # CLR transformation for rows, with pseudocount
-varespec.clr <- decostand(varespec+1, "clr")
+varespec.clr <- decostand(varespec, "clr", pseudocount=1)
 
 ## Chi-square: PCA similar but not identical to CA.
 ## Use wcmdscale for weighted analysis and identical results.

--- a/man/decostand.Rd
+++ b/man/decostand.Rd
@@ -69,30 +69,32 @@ wisconsin(x)
      \code{\link{vegdist}}), but the standardization can be used 
      independently of distance indices.
 
-     \item \code{clr}: centered log ratio (clr) transformation reduces the
-     data skewness and compositionality bias; see e.g. Gloor et al. (2017).
+     \item \code{clr}: centered log ratio ("clr") transformation proposed by
+     Aitchison (1986) reduces data skewness and compositionality bias.
+     This transformation has frequent applications in microbial ecology
+     (see e.g. Gloor et al., 2017).
      \deqn{clr = log_{10}\frac{x_{r}}{g(x_{r})} = log_{10}x_{r} - log_{10}µ_{r}}{%
-     clr = log10(x_r/g(x_r)) = log10 x_r - log10 µ_r},
-     where \eqn{x_{r}} is a single relative value, \eqn{g(x_{r})} is the geometric mean
+     clr = log10(x_r/g(x_r)) = log10 x_r - log10 µ_r} ,
+     where \eqn{x_{r}} is a single relative value, \eqn{g(x_{r})} is
+     the geometric mean
      of relative values per sample, and \eqn{\mu_{r}} is the arithmetic mean of 
-     relative values per sample. The method can operate only with positive data; a common
-     way to deal with zeroes is to add pseudocount.
+     relative values per sample. The method can operate only with positive data;
+     a common way to deal with zeroes is to add pseudocount.
 
-     \item \code{rclr}: robust clr (rclr) is similar to regular clr (see above).
-     One shortcoming in the regular clr is that logarithmic transformations
-     lead to undefined values when zeros are present in the data.
-     In rclr, values are divided by geometric mean
-     of observed taxa and zero values are not taken into account. Zero values will
-     stay as zeroes. Because of high dimensionality of data, rclr's geometric mean of 
-     observed taxa is a good approximation to the true geometric mean;
-     see e.g. Martino et al. (2019)
+     \item \code{rclr}: robust clr ("rclr") is similar to regular clr
+     (see above) but allows data that contains zeroes.
+     Robust clr divides the values by geometric mean
+     of the observed features; zero values are kept as zeroes, and not
+     taken into account. In high dimensional data,
+     the geometric mean of rclr is a good approximation of the true
+     geometric mean; see e.g. Martino et al. (2019)
      The \code{rclr} transformation is defined formally as follows:
      \deqn{rclr = log_{10}\frac{x_{r}}{g(x_{r} > 0)}}{%
      rclr = log10(x_r/g(x_r > 0))}
      where \eqn{x_{r}} is a single relative value, and \eqn{g(x_{r} > 0)} is geometric 
-     mean of sample-wide relative values that are positive (over 0).
-    
+     mean of sample-wide relative values that are positive (over 0).  
   }
+  
   Standardization, as contrasted to transformation, means that the
   entries are transformed relative to other entries.
 
@@ -117,11 +119,14 @@ wisconsin(x)
   \code{"method"}.
 }
 \author{Jari Oksanen, Etienne \enc{Laliberté}{Laliberte}
-  (\code{method = "log"}).}
+  (\code{method = "log"}), Leo Lahti (\code{"clr"} and \code{"rclr"}).}
 \note{Common transformations can be made with standard \R functions.}
 
 \references{ 
-  
+
+  Aitchison, J. The Statistical Analysis of Compositional Data (1986).
+  London, UK: Chapman & Hall.
+
   Anderson, M.J., Ellingsen, K.E. & McArdle, B.H. (2006) Multivariate
   dispersion as a measure of beta diversity. \emph{Ecology Letters} 
   \strong{9}, 683--693.

--- a/man/decostand.Rd
+++ b/man/decostand.Rd
@@ -67,7 +67,16 @@ wisconsin(x)
      Anderson et al. (2006) suggested this for their (strongly) modified
      Gower distance (implemented as \code{method = "altGower"} in 
      \code{\link{vegdist}}), but the standardization can be used 
-     independently of distance indices. 
+     independently of distance indices.
+
+    \item \code{clr}: centered log ratio (clr) transformation reduces the
+     data skewness and compositionality bias; see e.g. Gloor et al. (2017).
+     \deqn{clr = log_{10}\frac{x_{r}}{g(x_{r})} = log_{10}x_{r} - log_{10}µ_{r}}{%
+     clr = log10(x_r/g(x_r)) = log10 x_r - log10 µ_r},
+     where \eqn{x_{r}} is a single relative value, g(x_{r}) is the geometric mean
+     of relative values per sample, and \eqn{\mu_{r}} is the arithmetic mean of 
+     relative values per sample. The method can operate only with positive data; a common
+     way to deal with zeroes is to add pseudocount. 
   }
   Standardization, as contrasted to transformation, means that the
   entries are transformed relative to other entries.
@@ -102,6 +111,10 @@ wisconsin(x)
   dispersion as a measure of beta diversity. \emph{Ecology Letters} 
   \strong{9}, 683--693.
 
+  Gloor, G.B., Macklaim, J.M., Pawlowsky-Glahn, V. & Egozcue, J.J. (2017)
+  Microbiome Datasets Are Compositional: And This Is Not Optional.
+  \emph{Frontiers in Microbiology} \strong{8}, 2224. 
+
   Legendre, P. & Gallagher, E.D. (2001) Ecologically meaningful
   transformations for ordination of species data. \emph{Oecologia}
   \strong{129}, 271--280.
@@ -116,6 +129,9 @@ data(varespec)
 sptrans <- decostand(varespec, "max")
 apply(sptrans, 2, max)
 sptrans <- wisconsin(varespec)
+
+# CLR transformation for rows, with pseudocount
+varespec.clr <- decostand(varespec+1, "clr")
 
 ## Chi-square: PCA similar but not identical to CA.
 ## Use wcmdscale for weighted analysis and identical results.

--- a/man/decostand.Rd
+++ b/man/decostand.Rd
@@ -69,15 +69,29 @@ wisconsin(x)
      \code{\link{vegdist}}), but the standardization can be used 
      independently of distance indices.
 
-    \item \code{clr}: centered log ratio (clr) transformation reduces the
+     \item \code{clr}: centered log ratio (clr) transformation reduces the
      data skewness and compositionality bias; see e.g. Gloor et al. (2017).
      \deqn{clr = log_{10}\frac{x_{r}}{g(x_{r})} = log_{10}x_{r} - log_{10}µ_{r}}{%
      clr = log10(x_r/g(x_r)) = log10 x_r - log10 µ_r},
-     where \eqn{x_{r}} is a single relative value, g(x_{r}) is the geometric mean
+     where \eqn{x_{r}} is a single relative value, \eqn{g(x_{r})} is the geometric mean
      of relative values per sample, and \eqn{\mu_{r}} is the arithmetic mean of 
      relative values per sample. The method can operate only with positive data; a common
      way to deal with zeroes is to add pseudocount.
-     
+
+     \item \code{rclr}: robust clr (rclr) is similar to regular clr (see above).
+     One shortcoming in the regular clr is that logarithmic transformations
+     lead to undefined values when zeros are present in the data.
+     In rclr, values are divided by geometric mean
+     of observed taxa and zero values are not taken into account. Zero values will
+     stay as zeroes. Because of high dimensionality of data, rclr's geometric mean of 
+     observed taxa is a good approximation to the true geometric mean;
+     see e.g. Martino et al. (2019)
+     The \code{rclr} transformation is defined formally as follows:
+     \deqn{rclr = log_{10}\frac{x_{r}}{g(x_{r} > 0)}}{%
+     rclr = log10(x_r/g(x_r > 0))}
+     where \eqn{x_{r}} is a single relative value, and \eqn{g(x_{r} > 0)} is geometric 
+     mean of sample-wide relative values that are positive (over 0).
+    
   }
   Standardization, as contrasted to transformation, means that the
   entries are transformed relative to other entries.
@@ -119,6 +133,11 @@ wisconsin(x)
   Legendre, P. & Gallagher, E.D. (2001) Ecologically meaningful
   transformations for ordination of species data. \emph{Oecologia}
   \strong{129}, 271--280.
+
+  Martino, C., Morton, J.T., Marotz, C.A., Thompson, L.R., Tripathi, A.,
+  Knight, R. & Zengler, K. (2019) A novel sparse compositional technique
+  reveals microbial perturbations.
+  \emph{mSystems} \strong{4}, 1.
 
   Oksanen, J. (1983) Ordination of boreal heath-like vegetation with
   principal component analysis, correspondence analysis and

--- a/man/vegdist.Rd
+++ b/man/vegdist.Rd
@@ -17,7 +17,12 @@
   should be able to handle unknown (and variable) sample sizes. Most of
   these indices are discussed by Krebs (1999) and Legendre & Legendre
   (2012), and their properties further compared by Wolda (1981) and
-  Legendre & De \enc{Cáceres}{Caceres} (2012).
+  Legendre & De \enc{Cáceres}{Caceres} (2012). Aitchison (1986) distance 
+  is equivalent to Euclidean distance between CLR-transformed samples
+  (\code{"clr"}) and deals with positive compositional data.
+  Robust Aitchison distance by Martino et al. (2019) uses robust
+  CLR (\code{"rlcr"}), making it applicable to non-negative data
+  including zeroes (unlike the standard Aitchison).
 }
 
 \usage{vegdist(x, method="bray", binary=FALSE, diag=FALSE, upper=FALSE,
@@ -265,6 +270,13 @@
   metric, and probably should be preferred instead of the default
   Bray-Curtis which is semimetric. 
 
+  Aitchison distance (1986) and robust Aitchison distance
+  (Martino et al. 2019) are metrics. They can be useful to deal with
+  compositional, or relative data. Aitchison distance has been said to
+  outperform Jensen-Shannon divergence and Bray-Curtis dissimilarity,
+  due to a better stability to subsetting and aggregation, and it being a
+  linear distance (Aitchison et al., 2000).
+  
   The naming conventions vary. The one adopted here is traditional
   rather than truthful to priority. The function finds either
   quantitative or binary variants of the indices under the same name,
@@ -282,6 +294,15 @@
   return a distance object of the same type. 
 }
 \references{
+
+  Aitchison, J. The Statistical Analysis of Compositional Data (1986).
+  London, UK: Chapman & Hall.
+
+  Aitchison, J., \enc{Barceló-Vidal}{Barcelo-Vidal}, C.,
+  \enc{Martín-Fernández}{Martin-Fernandez}, J.A., Pawlowsky-Glahn, V. (2000).
+  Logratio analysis and compositional distance.
+  \emph{Math. Geol.} \strong{32}, 271–275.
+
   Anderson, M.J. and Millar, R.B. (2004). Spatial variation and effects
   of habitat on temperate reef fish assemblages in northeastern New
   Zealand.  \emph{Journal of Experimental Marine Biology and Ecology}
@@ -329,6 +350,10 @@
   Mardia, K.V., Kent, J.T. and Bibby, J.M. (1979). \emph{Multivariate analysis}.
   Academic Press.
 
+  Martino, C., Morton, J.T., Marotz, C.A., Thompson, L.R., Tripathi, A.,
+  Knight, R. & Zengler, K. (2019) A novel sparse compositional technique
+  reveals microbial perturbations. \emph{mSystems} \strong{4}, 1.
+  
   Mountford, M. D. (1962). An index of similarity and its application to
   classification problems. In: P.W.Murphy (ed.),
   \emph{Progress in Soil Zoology}, 43--50. Butterworths.
@@ -340,8 +365,9 @@
   diversity. \emph{Oecologia} 50, 296--302.
 }
 
-\author{ Jari Oksanen, with contributions from Tyler Smith (Gower index)
-  and Michael Bedward (Raup--Crick index). }
+\author{ Jari Oksanen, with contributions from Tyler Smith (Gower index),
+  Michael Bedward (Raup--Crick index), and
+  Leo Lahti (Aitchison and robust Aitchison distance). }
 
 \note{The function is an alternative to \code{\link{dist}} adding some
   ecologically meaningful indices.  Both methods should produce similar

--- a/man/vegdist.Rd
+++ b/man/vegdist.Rd
@@ -35,7 +35,8 @@
     \code{"jaccard"}, \code{"gower"}, \code{"altGower"},
     \code{"morisita"}, \code{"horn"}, \code{"mountford"}, \code{"raup"},
     \code{"binomial"}, \code{"chao"}, \code{"cao"}, \code{"mahalanobis"},
-    \code{"chisq"} or \code{"chord"}.}
+    \code{"chisq"}, \code{"chord"}, \code{"aitchison"}, or
+    \code{"aitchison_robust"}.}
   \item{binary}{Perform presence/absence standardization before analysis
     using \code{\link{decostand}}.}
   \item{diag}{Compute diagonals. }
@@ -44,7 +45,9 @@
     computing dissimilarities.}
   \item{\dots}{Other parameters.  These are ignored, except in
     \code{method ="gower"} which accepts \code{range.global} parameter of
-    \code{\link{decostand}}. .}
+    \code{\link{decostand}}, and in \code{method="aitchison"}, which
+    accepts \code{pseudocount} parameter of \code{\link{decostand}} used
+    in the \code{clr} transformation.}
 }
 
 \details{Jaccard (\code{"jaccard"}), Mountford (\code{"mountford"}),
@@ -271,18 +274,19 @@
   Bray-Curtis which is semimetric. 
 
   Aitchison distance (1986) and robust Aitchison distance
-  (Martino et al. 2019) are metrics. They can be useful to deal with
-  compositional, or relative data. Aitchison distance has been said to
+  (Martino et al. 2019) are metrics that deal with
+  compositional data. Aitchison distance has been said to
   outperform Jensen-Shannon divergence and Bray-Curtis dissimilarity,
   due to a better stability to subsetting and aggregation, and it being a
-  linear distance (Aitchison et al., 2000).
+  proper distance (Aitchison et al., 2000).
   
   The naming conventions vary. The one adopted here is traditional
   rather than truthful to priority. The function finds either
   quantitative or binary variants of the indices under the same name,
   which correctly may refer only to one of these alternatives For
   instance, the Bray
-  index is known also as Steinhaus, Czekanowski and \enc{Sørensen}{Sorensen} index.
+  index is known also as Steinhaus, Czekanowski and
+  \enc{Sørensen}{Sorensen} index.
   The quantitative version of Jaccard should probably called
   \enc{Ružička}{Ruzicka} index.
   The abbreviation \code{"horn"} for the Horn--Morisita index is


### PR DESCRIPTION
This PR solves #433 and provides:

New transformation to `vegan::decostand`:
- CLR transformation ("`clr`")
- robust CLR transformation ("`rclr`") 

New distance to `vegan::vegdist`:
- Aitchison distance ("`aitchison`")
- robust Aitchison distance ("`aitchison_robust`")

These options are documented, references and unit tests have been provided. The automated build & checks seem to go through.

Remaining questions:
- Are contributors listed in DESCRIPTION (I could add this to the PR)? The newer formats often include authors with different roles in this file (see [here](https://www.oreilly.com/library/view/r-packages/9781491910580/ch04.html)), like "creator", "author", "contributor" etc. But the current system does not use this format so I am not sure. Can also add an update to the full author listing format, if this is desirable and could fit in the same PR.
- NEWS file update? Would require opening up a new section with an updated version number.
- Any other issues, happy to fix!

Also thanks to the colleagues Felix Ernst & Tuomas Borman for contributions to the code via the *mia* package, from which these were transferred and modified.




