### PR TITLE
Use !anyNA() over all(!is.na(.))

### DIFF
--- a/R/plot.cca.R
+++ b/R/plot.cca.R
@@ -117,7 +117,7 @@
         biplabs <- ordiArrowTextXY(mul * g$regression, rownames(g$regression))
         text(biplabs, rownames(g$regression), col = rcol)
     }
-    if (!is.null(g$centroids) && all(!is.na(g$centroids)) && type !=
+    if (!is.null(g$centroids) && !anyNA(g$centroids) && type !=
         "none") {
         if (type == "text")
             text(g$centroids, rownames(g$centroids), col = "blue")

--- a/R/summary.cca.R
+++ b/R/summary.cca.R
@@ -8,7 +8,7 @@
     ## scaling is stored in return object so must be in numeric format
     scaling <- scalingType(scaling = scaling, correlation = correlation,
                            hill = hill)
-    if (axes && length(display) && (all(!is.na(display)) && !is.null(display)))
+    if (axes && length(display) && !anyNA(display) && !is.null(display))
         summ <- scores(object, scaling = scaling, choices = 1:axes, display = display,
                        ...)
     ## scores() drops list to a matrix if there is only one item: workaround below.


### PR DESCRIPTION
`all(!(.))` is logically equivalent to `!any(.)`; in this case, that means we can use the specialized `anyNA()` instead as well