### PR TITLE
Fix for proxy package breaking `simper()`

### DIFF
--- a/R/simper.R
+++ b/R/simper.R
@@ -18,7 +18,7 @@
     rs <- rowSums(comm)
     rs <- outer(rs, rs, "+")[tri]
     spcontr <- sapply(seq_len(ncol(comm)),
-                      function(i) vegdist(comm[,i,drop=FALSE], "man"))
+        function(i) as.vector(vegdist(comm[, i, drop = FALSE], "man")))
     ## Bray-Curtis
     spcontr <- sweep(spcontr, 1, rs, "/")
     colnames(spcontr) <- colnames(comm)


### PR DESCRIPTION
This PR implements a simple fix to `simper()` that is similar to that suggested by @EDiLD in #528 but using the "guidance" of R Core to use `as.vector()` when one wants the side effects of `c` `?c`.