### PR TITLE
testing out `drop = F` in `simper`, so `colMeans` can work

### DIFF
--- a/R/simper.R
+++ b/R/simper.R
@@ -64,7 +64,7 @@
                 Pval <- rep(1, ncol(comm))
                 for (k in seq_len(nperm)) {
                     take <- tmat[permat[k,],permat[k,]][tri]
-                    Pval <- Pval + ((colMeans(spcontr[take,]) - EPS) >= average)
+                    Pval <- Pval + ((colMeans(spcontr[take,,drop = FALSE]) - EPS) >= average)
                 }
                 Pval <- Pval/(nperm+1)
             } else {


### PR DESCRIPTION
Fix for github issue #543