### PR TITLE
Use ISHFT for powers of 2

### DIFF
--- a/src/monoMDS.f
+++ b/src/monoMDS.f
@@ -382,7 +382,7 @@ C
       IF (N.LT.2) RETURN
       FN=REAL(N)
       NLOOPS=MAX(NINT(LOG(FN)/LOG(2.)),1)
-      M=ISHFT(2,NLOOPS-1)
+      M=ISHFT(1,NLOOPS-1)
       DO II=1,NLOOPS
         FM=M
         DO I=1,MAX(1,N-M)

--- a/src/monoMDS.f
+++ b/src/monoMDS.f
@@ -382,7 +382,7 @@ C
       IF (N.LT.2) RETURN
       FN=REAL(N)
       NLOOPS=MAX(NINT(LOG(FN)/LOG(2.)),1)
-      M=ISHFT(1,NLOOPS-1)
+      M=ISHFT(1,NLOOPS-1) ! i.e., 2^(N_LOOPS-1) using bit shifts
       DO II=1,NLOOPS
         FM=M
         DO I=1,MAX(1,N-M)

--- a/src/monoMDS.f
+++ b/src/monoMDS.f
@@ -382,7 +382,7 @@ C
       IF (N.LT.2) RETURN
       FN=REAL(N)
       NLOOPS=MAX(NINT(LOG(FN)/LOG(2.)),1)
-      M=2**(NLOOPS-1)
+      M=ISHFT(2,NLOOPS-1)
       DO II=1,NLOOPS
         FM=M
         DO I=1,MAX(1,N-M)


### PR DESCRIPTION
Context: a bug in our build system led to vegan failing to compile in some cases because of this exponentiation.

While that bug is our own to fix, it does strike me that `ISHFT()` is preferable for calculating powers of 2 in particular (and it solved our issue to boot):

https://gcc.gnu.org/onlinedocs/gfortran/ISHFT.html
