### PR TITLE
"fix" roxygen markup for internal function

### DIFF
--- a/R/ordiareatest.R
+++ b/R/ordiareatest.R
@@ -6,7 +6,7 @@
 #' @param ord 2-d ordination
 #' @param factor defining groups
 #' @param are of convex hull of or an ellipse
-#' @param permutations: number, permutation matrix or a
+#' @param permutations number, permutation matrix or a
 #' \code{\link[permute]{how}} definition.
 #' @param parallel parallel processing
 #' @param \dots other parameters passed to area functions


### PR DESCRIPTION
Came across this by accident in an over-wide Ctrl+F, so offering the fix. Not really a bug since the function is interal.