### PR TITLE
Fix anova.cca

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Authors@R: c(person("Jari", "Oksanen", role=c("aut","cre"),
 	   person("Tyler", "Smith", role="aut"),
 	   person("Adrian", "Stier", role="aut"),
 	   person("Cajo J.F.", "Ter Braak", role="aut"),
-	   person("James", "Weedon", role="aut"))
+	   person("James", "Weedon", role="aut"),
+	   person("Tuomas", "Borman", role="aut"))
 Depends: permute (>= 0.9-0), lattice, R (>= 4.1.0)
 Suggests: parallel, knitr, markdown, vegan3d (>= 1.3-0)
 Imports: MASS, cluster, mgcv

--- a/R/anova.ccabyterm.R
+++ b/R/anova.ccabyterm.R
@@ -101,10 +101,15 @@
     Chisq <- sapply(mods, function(x) x$chi[2]) - chibig
     Fstat <- (Chisq/Df)/(chibig/dfbig)
     ## Simulated F-values
-    Fval <- sapply(mods, function(x) x$num)
-    ## Had we an empty model we need to clone the denominator
-    if (length(Fval) == 1)
-        Fval <- matrix(Fval, nrow = nperm)
+    Fval <- sapply(mods, function(x){
+        ## Get the permutation test results for a certain variable
+        temp <- x$num
+        ## If this variable did not explain any variance, no permutation test
+        ## was applied. In that case, give vector with zeroes.
+        if( x$nperm == 0 ) temp <- rep(0, nperm)
+        return(temp)
+        })
+    ## Calculate explained variance
     Fval <- sweep(-Fval, 1, big$num, "+")
     Fval <- sweep(Fval, 2, Df, "/")
     Fval <- sweep(Fval, 1, scale, "/")


### PR DESCRIPTION
1.

In constrained ordination models such as dbrda, variables that are collinear and do not explain any variance are excluded from the model. For example, if a user models patient ID as a random effect along with other explanatory variables (sample type, diagnosis), collinear variables such as diagnosis may be excluded

`data ~ sample_type + diagnosis + Condition(patient_id)`

2.

When testing for the significance of the variance explained by each variable, `anova.cca(by = "margin")` calls `permutest()` for each variable.

https://github.com/vegandevs/vegan/blob/cf603e13d20f073b6f93c2ab2a978b0ac00e39a0/R/anova.ccabyterm.R#L93

If a variable is excluded from the model due to collinearity, no constrained variance is available, and `permutest()` returns a result with `num = 0`.

https://github.com/vegandevs/vegan/blob/cf603e13d20f073b6f93c2ab2a978b0ac00e39a0/R/permutest.cca.R#L13

3.

The current implementation works if the excluded variable is the only variable in the model. In this case, the method successfully handles the situation. However, if the model contains both variables that explain variance and variables that do not, the function produces an error.

The error is caused because this line below outputs a list instead of `matrix` or `numeric scalar`:

https://github.com/vegandevs/vegan/blob/cf603e13d20f073b6f93c2ab2a978b0ac00e39a0/R/anova.ccabyterm.R#L104

Single numeric value is detected by this line that converts it to `matrix`:

https://github.com/vegandevs/vegan/blob/cf603e13d20f073b6f93c2ab2a978b0ac00e39a0/R/anova.ccabyterm.R#L106

If the values are not in `matrix` format, this line below causes an error:

https://github.com/vegandevs/vegan/blob/cf603e13d20f073b6f93c2ab2a978b0ac00e39a0/R/anova.ccabyterm.R#L108

4.

I fixed the error by ensuring that the values are in `matrix` format (ncol = N variables, nrow = N permutations). If certain variable was excluded from the model, the corresponding column is filled with 0s.

The code below reproduces the problem

```
library(vegan)
data(dune)
data(dune.env)

# Add collinear variable
dune.env[["Use_detail"]] <- as.character(dune.env[["Use"]])
dune.env[1, "Use_detail"] <- "something"
# WORKS
rda <- rda(dune ~ Manure + Condition(Use_detail), dune.env)
anova.cca(rda, by = "margin")
# DO NOT WORK
rda <- rda(dune ~ Manure + Use + Condition(Use_detail), dune.env)
anova.cca(rda, by = "margin")
```

-Tuomas