### PR TITLE
Parallel processing: bug fix + robustification

### DIFF
--- a/R/anosim.R
+++ b/R/anosim.R
@@ -67,10 +67,9 @@
             } else {
                 if (!hasClus) {
                     parallel <- makeCluster(parallel)
+                    on.exit(stopCluster(parallel))
                 }
                 perm <- parRapply(parallel, permat, ptest)
-                if (!hasClus)
-                    stopCluster(parallel)
             }
         } else {
             perm <- sapply(1:permutations, function(i) ptest(permat[i,]))

--- a/R/cascadeKM.R
+++ b/R/cascadeKM.R
@@ -54,12 +54,12 @@ function(data, inf.gr, sup.gr, iter = 100, criterion="calinski",
       })
     } else {
         if(hasClus || .Platform$OS.type == "windows") {
-            if(!hasClus)
-                cl <- makeCluster(parallel)
-            tmp <- parLapply(cl, inf.gr:sup.gr, function (ii)
-                kmeans(data, ii, iter.max = 50, nstart = iter))
-            if (!hasClus)
-                stopCluster(cl)
+            if (!hasClus) {
+                parallel <- makeCluster(parallel)
+                on.exit(stopCluster(parallel))
+            }
+            tmp <- parLapply(parallel, inf.gr:sup.gr, function (ii)
+                    kmeans(data, ii, iter.max = 50, nstart = iter))
         } else { # "unix"
             tmp <- mclapply(inf.gr:sup.gr, function (ii)
                 kmeans(data, ii, iter.max = 50, nstart = iter),

--- a/R/estaccumR.R
+++ b/R/estaccumR.R
@@ -22,10 +22,9 @@
         } else {
             if (!hasClus) {
                 parallel <- makeCluster(parallel)
+                on.exit(stopCluster(parallel))
             }
             tmp <- parLapply(parallel, 1:nperm, function(i) estFun(permat[i,]))
-            if (!hasClus)
-                stopCluster(parallel)
         }
     } else {
         tmp <- lapply(1:nperm, function(i) estFun(permat[i,]))

--- a/R/mantel.R
+++ b/R/mantel.R
@@ -56,10 +56,9 @@
             } else {
                 if (!hasClus) {
                     parallel <- makeCluster(parallel)
+                    on.exit(stopCluster(parallel))
                 }
                 perm <- parRapply(parallel, permat, ptest)
-                if (!hasClus)
-                    stopCluster(parallel)
             }
         } else {
             perm <- sapply(1:permutations, function(i, ...) ptest(permat[i,], ...))

--- a/R/mantel.partial.R
+++ b/R/mantel.partial.R
@@ -72,10 +72,9 @@
             } else {
                 if (!hasClus) {
                     parallel <- makeCluster(parallel)
+                    on.exit(stopCluster(parallel))
                 }
                 perm <- parRapply(parallel, permat, ptest)
-                if (!hasClus)
-                    stopCluster(parallel)
             }
         } else {
             perm <- sapply(1:permutations, function(i, ...) ptest(permat[i,], ...))

--- a/R/metaMDSiter.R
+++ b/R/metaMDSiter.R
@@ -82,6 +82,7 @@
     isMulticore <- .Platform$OS.type == "unix" && !hasClus
     if (isParal && !isMulticore && !hasClus) {
         parallel <- makeCluster(parallel)
+        on.exit(stopCluster(parallel))
         clusterEvalQ(parallel, library(vegan))
     }
     ## get the number of clusters
@@ -156,9 +157,6 @@
             cat("*** Best solution was not repeated\n")
         }
     }
-    ## stop socket cluster
-    if (isParal && !isMulticore && !hasClus)
-        stopCluster(parallel)
     if (!missing(previous.best) && inherits(previous.best, "metaMDS")) {
         tries <- tries + previous.best$tries
     }

--- a/R/mrpp.R
+++ b/R/mrpp.R
@@ -61,11 +61,10 @@
             } else {
                 if (!hasClus) {
                     parallel <- makeCluster(parallel)
+                    on.exit(stopCluster(parallel))
                 }
                 m.ds <- parCapply(parallel, perms, function(x)
                                   mrpp.perms(x, dmat, indls, w))
-                if (!hasClus)
-                    stopCluster(parallel)
             }
         } else {
             m.ds <- apply(perms, 2, function(x) mrpp.perms(x, dmat, indls, w))

--- a/R/oecosimu.R
+++ b/R/oecosimu.R
@@ -117,6 +117,7 @@
             ## if hasClus, do not set up and stop a temporary cluster
             if (!hasClus) {
                 parallel <- makeCluster(parallel)
+                on.exit(stopCluster(parallel))
                 ## make vegan functions available: others may be unavailable
                 clusterEvalQ(parallel, library(vegan))
             }
@@ -128,8 +129,6 @@
                                          applynestfun(z, fun = nestfun,
                                                       statistic = statistic, ...)))
             }
-            if (!hasClus)
-                stopCluster(parallel)
         }
     } else {
         for(i in seq_len(nbatch)) {

--- a/R/ordiareatest.R
+++ b/R/ordiareatest.R
@@ -40,10 +40,9 @@
             } else {
                 if (!hasClus) {
                     parallel <- makeCluster(parallel)
+                    on.exit(stopCluster(parallel))
                 }
                 areas <- parApply(parallel, perm, MARGIN=1, pfun)
-                if (!hasClus)
-                    stopCluster(parallel)
             }
     } else {
         areas <- sapply(1:nperm, function(i, ...) pfun(perm[i,], ...))

--- a/R/permutest.betadisper.R
+++ b/R/permutest.betadisper.R
@@ -92,6 +92,7 @@
             ## if hasClus, don't set up and top a temporary cluster
             if (!hasClus) {
                 parallel <- makeCluster(parallel)
+                on.exit(stopCluster(parallel))
             }
 
             Pstats <- parApply(parallel, permutations, 1,
@@ -100,10 +101,6 @@
                 Pstats <- matrix(Pstats) # one-column matrix
             } else {
                 Pstats <- t(Pstats) # transpose statistics to columns
-            }
-
-            if (!hasClus) {
-                stopCluster(parallel)
             }
         }
     } else {

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -182,6 +182,7 @@ permutest.default <- function(x, ...)
             ## if hasClus, do not set up and stop a temporary cluster
             if (!hasClus) {
                 parallel <- makeCluster(parallel)
+                on.exit(stopCluster(parallel))
             }
             tmp <- do.call(rbind,
                            parLapply(parallel,
@@ -191,8 +192,6 @@ permutest.default <- function(x, ...)
                                      E = E, Q = Q, QZ = QZ, effects = effects, w = w,
                                      first = first, isPartial = isPartial,
                                      isCCA = isCCA, isDB = isDB, q = q, r = r))
-            if (!hasClus)
-                stopCluster(parallel)
         }
     } else {
         tmp <- getF(permutations, E = E, Q = Q, QZ = QZ, effects = effects,


### PR DESCRIPTION
* BUG FIX: cascadeKM(..., parallel = <cluster>) uses non-defined 'cl object [#771]
* ROBUSTINESS: Make sure all temporarily created parallel cluster are always closed, also on error