### PR TITLE
Fix Misspellings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -866,7 +866,7 @@
   [\#497](https://github.com/vegandevs/vegan/issues/497).
 
 * `metaMDS` adopted a more user-friendly policy, and `trymax` will
-  always be the maximum number of tries. See dicussion in
+  always be the maximum number of tries. See discussion in
   https://stackoverflow.com/questions/66748605/.
 
 * `adonis2` accepts `strata`. `adonis2` is the new main function that
@@ -2169,7 +2169,7 @@
   The argument can be an integer giving the number of parallel
   processes. In unix-alikes (Mac OS, Linux) this will launch
   `"multicore"` processing and in Windows it will set up `"snow"`
-  clusters as desribed in the documentation of the parallel package. If
+  clusters as described in the documentation of the parallel package. If
   `option` `"mc.cores"` is set to an integer \> 1, this will be used to
   automatically start parallel processing. Finally, the argument can
   also be a previously set up `"snow"` cluster which will be used both
@@ -2182,7 +2182,7 @@
   permutation statistics: `adonis`, `anosim`, `anova.cca` (and
   `permutest.cca`), `mantel` (and `mantel.partial`), `mrpp`,
   `ordiareatest`, `permutest.betadisper` and `simper`. In addition,
-  `bioenv` can compare several candidate sets of models in paralle,
+  `bioenv` can compare several candidate sets of models in parallel,
   `metaMDS` can launch several random starts in parallel, and `oecosimu`
   can evaluate test statistics for several null models in parallel.
 
@@ -2197,7 +2197,7 @@
   use external or user constructed permutations.
   
   See `help(permutations)` for a brief introduction on permutations in
-  vegan, and permute package for the full documention. The vignette of
+  vegan, and permute package for the full documentation. The vignette of
   the permute package can be read from vegan with command
   `vegandocs("permutations")`.
   
@@ -2265,7 +2265,7 @@
   methods), `permutest.betadisper`, and `protest`.
 
 * `stressplot` functions display the ordination distances at given
-  number of dimensions against original distances. The method functins
+  number of dimensions against original distances. The method functions
   are similar to `stressplot` for `metaMDS`, and always use the inherent
   distances of each ordination method. The functions are available for
   the results `capscale`, `cca`, `princomp`, `prcomp`, `rda`, and
@@ -2766,7 +2766,7 @@
 
 * Some constrained ordination methods and their support functions are
   more robust in border cases (completely aliased effects, saturated
-  models, user requests for non-existng scores etc). Concerns
+  models, user requests for non-existing scores etc). Concerns
   `capscale`, `ordistep`, `varpart`, `plot` function for constrained
   ordination, and `anova(<cca.object>, by = "margin")`.
 

--- a/R/GowerDblcen.R
+++ b/R/GowerDblcen.R
@@ -1,6 +1,6 @@
 ### Internal function for double centring of a *matrix* of
 ### dissimilarities. We used .C("dblcen", ..., PACKAGE = "stats")
-### which does not dublicate its argument, but it was removed from R
+### which does not duplicate its argument, but it was removed from R
 ### in r60360 | ripley | 2012-08-22 07:59:00 UTC (Wed, 22 Aug 2012)
 ### "more conversion to .Call, clean up". Input 'x' *must* be a
 ### matrix. This was originally an internal function in betadisper.R

--- a/R/anova.ccabyterm.R
+++ b/R/anova.ccabyterm.R
@@ -88,7 +88,7 @@
     ass <- object$terminfo$assign
     if (is.null(ass))
         stop("old style result object: update() your model")
-    ## analyse only terms of 'ass' thar are in scope
+    ## analyse only terms of 'ass' that are in scope
     scopeterms <- which(alltrms %in% trmlab)
     mods <- suppressMessages(
         lapply(scopeterms, function(i, ...)

--- a/R/as.hclust.spantree.R
+++ b/R/as.hclust.spantree.R
@@ -65,7 +65,7 @@
 }
 
 ### Reorder an hclust tree. Basic R provides reorder.dendrogram, but
-### this functoin works with 'hclust' objects, and also differs in
+### this function works with 'hclust' objects, and also differs in
 ### implementation. We use either weighted mean, min or max or
 ### sum. The dendrogram is always ordered in ascending order, so that
 ### with max the left kid always has lower value. So with 'max' the

--- a/R/betadisper.R
+++ b/R/betadisper.R
@@ -3,7 +3,7 @@
              sqrt.dist = FALSE, add = FALSE)
 {
     ## inline function for double centring. We used .C("dblcen", ...,
-    ## PACKAGE = "stats") which does not dublicate its argument, but
+    ## PACKAGE = "stats") which does not duplicate its argument, but
     ## it was removed from R in r60360 | ripley | 2012-08-22 07:59:00
     ## UTC (Wed, 22 Aug 2012) "more conversion to .Call, clean up".
     dblcen <- function(x, na.rm = TRUE) {

--- a/R/clamtest.R
+++ b/R/clamtest.R
@@ -4,7 +4,7 @@ clamtest <-
 function(comm, groups, coverage.limit = 10,
 specialization = 2/3, npoints = 20, alpha = 0.05/20)
 {
-    ## inital checks
+    ## initial checks
     comm <- as.matrix(comm)
     if (NROW(comm) < 2)
         stop("'comm' must have at least two rows")

--- a/R/downweight.R
+++ b/R/downweight.R
@@ -24,7 +24,7 @@
     veg
 }
 
-## Hill's piecewise tranformation. Values of before are replaced with
+## Hill's piecewise transformation. Values of before are replaced with
 ## values of after, and intermediary values with linear interpolation.
 
 ## Not exported: if you think you need something like this, find a

--- a/R/ordConstrained.R
+++ b/R/ordConstrained.R
@@ -3,7 +3,7 @@
 ### matrix and after that the partializing, constraining and residual
 ### steps are very similar to each other. This file provides functions
 ### that can analyse any classic method, the only difference being the
-### attributes of the dependet variable.
+### attributes of the dependent variable.
 
 ### In this file we use convention modelfunction(Y, X, Z) where Y is
 ### the dependent data set (community), X is the model matrix of
@@ -28,7 +28,7 @@
 ### of constraints, Z the model matrix of conditions, method is "cca",
 ### "rda", "capscale" or "dbrda" (the last two may not work, and
 ### "capscale" may not work in the way you assume). The function
-### returns a large subset of correspoding constrained ordination
+### returns a large subset of corresponding constrained ordination
 ### method. For instance, with method = "dbrda", the result is mainly
 ### correct, but it differs so much from the current dbrda that it
 ### cannot be printed cleanly.

--- a/R/orderingKM.R
+++ b/R/orderingKM.R
@@ -5,7 +5,7 @@
 ### INPUT :
 ### mat		(n x k): n the objects and k the descriptors
 ### 			This matrix must be integers and numeric
-###			And must not be binairy, it is the partition matrix
+###			And must not be binary, it is the partition matrix
 ###			output by cascadeKM
 ### OUTPUT :  Ordered matrix
 

--- a/R/ordiParseFormula.R
+++ b/R/ordiParseFormula.R
@@ -8,7 +8,7 @@ function (formula, data, xlev = NULL, na.action = na.fail,
     flapart <- fla <- formula <- formula(Terms, width.cutoff = 500)
     ## distance-based methods (capscale, dbrda) evaluate specdata (LHS
     ## in formula) within their code, and the handling in
-    ## ordiParseFormula is redundand and can be expensive
+    ## ordiParseFormula is redundant and can be expensive
     if (missing(X)) {
         specdata <- formula[[2]]
         X <- eval(specdata, environment(formula), enclos=globalenv())
@@ -75,7 +75,7 @@ function (formula, data, xlev = NULL, na.action = na.fail,
     if (NROW(mf) > 0) {
         ## We need to re-construct model.frame and its formula, and
         ## for this names with functions must be back-quoted
-        ## (`poly(A1, 2)`, e.g.) with the curren scoping to find the
+        ## (`poly(A1, 2)`, e.g.) with the current scoping to find the
         ## variable (A1) later. This happened with formula(mf) in R <
         ## 3.6.0, but now we must be explicit.
         mf <- model.frame(as.formula(paste("~",

--- a/R/pcnm.R
+++ b/R/pcnm.R
@@ -10,7 +10,7 @@
     }
     dis[dis > threshold] <- 4*threshold
     ## vegan:::wcmdscale is able to use weights which also means that
-    ## 'k' need not be given, but all vecctors with >0 eigenvalues
+    ## 'k' need not be given, but all vectors with >0 eigenvalues
     ## will be found
     mypcnm <- wcmdscale(dis, eig = TRUE, w=w)
     res <- list(vectors = mypcnm$points, values = mypcnm$eig,

--- a/R/permutest.cca.R
+++ b/R/permutest.cca.R
@@ -34,7 +34,7 @@ permutest.default <- function(x, ...)
     isCCA <- !is.null(w)
     isPartial <- !is.null(x$pCCA) && x$pCCA$rank > 0   # handle conditions
     isDB <- inherits(x, c("dbrda")) # only dbrda is distance-based
-    ## C function to get the statististics in one loop
+    ## C function to get the statistics in one loop
     getF <- function(indx, E, Q, QZ, effects, w, first, isPartial, isCCA,
                      isDB, q, r)
     {

--- a/R/predict.radline.R
+++ b/R/predict.radline.R
@@ -15,7 +15,7 @@
     ## total number of individuals in the community
     if (missing(total))
         total <- sum(object$y)
-    ## adjustment for chagned total in call
+    ## adjustment for changed total in call
     adj <- total/sum(object$y)
     nobs <- length(object$y)
     p <- coef(object)

--- a/R/predict.rda.R
+++ b/R/predict.rda.R
@@ -139,7 +139,7 @@
             nm <- rownames(u)
             automaticnames <- .row_names_info(newdata) < 0
             if (automaticnames)
-                message("'newdata' cannot be mathced with automatic rownames")
+                message("'newdata' cannot be matched with automatic rownames")
             if (!is.null(nm) && !automaticnames) {
                 if (!all(nm %in% rownames(newdata)))
                     stop("'newdata' does not have named rows matching one or more of the original rows")

--- a/R/procrustes.R
+++ b/R/procrustes.R
@@ -7,7 +7,7 @@
         stop(gettextf("matrices have different number of rows: %d and %d",
              nrow(X), nrow(Y)))
     if (ncol(X) < ncol(Y)) {
-        warning("X has fewer axes than Y: X adjusted to comform Y\n")
+        warning("X has fewer axes than Y: X adjusted to conform Y\n")
         addcols <- ncol(Y) - ncol(X)
         for (i in 1:addcols) X <- cbind(X, 0)
     }

--- a/R/procrustes.R
+++ b/R/procrustes.R
@@ -7,7 +7,7 @@
         stop(gettextf("matrices have different number of rows: %d and %d",
              nrow(X), nrow(Y)))
     if (ncol(X) < ncol(Y)) {
-        warning("X has fewer axes than Y: X adjusted to conform Y\n")
+        warning("X has fewer axes than Y: X adjusted to conform to Y\n")
         addcols <- ncol(Y) - ncol(X)
         for (i in 1:addcols) X <- cbind(X, 0)
     }

--- a/R/simulate.rda.R
+++ b/R/simulate.rda.R
@@ -264,7 +264,7 @@
 ### simulate.dbrda cannot be done along similar lines as
 ### simulate.capscale, because low-rank approximation needs column
 ### scores v and cannot be found only from row scores u that are the
-### only ones we have in dbrda(). Residuals also need exra thinking,
+### only ones we have in dbrda(). Residuals also need extra thinking,
 ### and therefore we just disable simulate.dbrda()
 
 `simulate.dbrda` <-

--- a/R/smbind.R
+++ b/R/smbind.R
@@ -113,9 +113,9 @@
         }
         if (type == "none") {
             if (strict) {
-                stop("incosistent 'start', 'end', 'thin' attributes")
+                stop("inconsistent 'start', 'end', 'thin' attributes")
             } else {
-                warning("incosistent 'start', 'end', 'thin' attributes")
+                warning("inconsistent 'start', 'end', 'thin' attributes")
             }
         }
     }

--- a/R/specslope.R
+++ b/R/specslope.R
@@ -26,7 +26,7 @@
     if (!(object$method %in% accepted))
         stop(gettextf("accumulation method must be one of: %s",
              paste(accepted, collapse=", ")))
-    ## Funcions should accept a vector of 'at', but usually they
+    ## Functions should accept a vector of 'at', but usually they
     ## don't. I don't care to change this, and therefore we check the
     ## input.
     if (length(at) > 1 && object$method %in% c("exact", "coleman"))

--- a/R/veganCovEllipse.R
+++ b/R/veganCovEllipse.R
@@ -1,7 +1,7 @@
 `veganCovEllipse` <-
     function(cov, center = c(0,0), scale = 1, npoints = 100)
 {
-    ## Basically taken from the 'car' package: The Circle
+    ## Basically taken from the 'car' package: The circle
     theta <- (0:npoints) * 2 * pi/npoints
     Circle <- cbind(cos(theta), sin(theta))
     ## scale, center and cov must be calculated separately

--- a/R/veganCovEllipse.R
+++ b/R/veganCovEllipse.R
@@ -1,7 +1,7 @@
 `veganCovEllipse` <-
     function(cov, center = c(0,0), scale = 1, npoints = 100)
 {
-    ## Basically taken from the 'car' package: The Cirlce
+    ## Basically taken from the 'car' package: The Circle
     theta <- (0:npoints) * 2 * pi/npoints
     Circle <- cbind(cos(theta), sin(theta))
     ## scale, center and cov must be calculated separately

--- a/inst/ONEWS
+++ b/inst/ONEWS
@@ -2012,7 +2012,7 @@ Version 1.6-0 (Fisher)
 
 	* rarefy: Can now optionally find SE of rarefied richness.
 
-	* renyi: A new function to find Rï¿½nyi diversities or Hill numbers
+	* renyi: A new function to find Rényi diversities or Hill numbers
 	with any scale (thanks to Roeland Kindt).
 
 	* scores.ordiplot: should be more robust now.

--- a/inst/ONEWS
+++ b/inst/ONEWS
@@ -1151,7 +1151,7 @@ NEW FEATURES AND FIXES
 
     - fitted.cca, fitted.rda gained argument type = "working" to get
       the fitted values and residuals used internally in calculation
-      (in cca() these are weigthed and Chi-square standardized
+      (in cca() these are weighted and Chi-square standardized
       values).
 
     - isomap checks that input data are dissimilarities or can be
@@ -1322,7 +1322,7 @@ Version 1.8-5 (January 11, 2007)
 	* Based on devel version 1.9-12.
 	
 	* no.shared (manifest in metaMDS): prints thousands of lines of
-	debugging info that I forgot to deactive in release. Not fatal,
+	debugging info that I forgot to deactivate in release. Not fatal,
 	but extremely annoying.
 
 	* capscale: inertia name as "unknown" if the dissimilarity object
@@ -1458,7 +1458,7 @@ Version 1.8-1 (June 12, 2006)
 	
 	* intersetcor: new function for the interset correlation or the
 	(weighted) correlation between individual constraints (contrasts)
-	and invidual axes in cca/rda/capscale. (Not recommended.)
+	and individual axes in cca/rda/capscale. (Not recommended.)
 
 	* decostand: does not automatically convert matrix to a
 	data.frame. NA handling more consistent now (thanks to Tyler Smith
@@ -1544,13 +1544,13 @@ Version 1.8-1 (June 12, 2006)
 	* vegdist: now first checks input and then transforms (if
 	needed). Thanks to Tyler Smith,
 
-	* Internal changes: permuted.index acceptes NULL strata as an
+	* Internal changes: permuted.index accepts NULL strata as an
 	alternative to missing strata. ordispantreee deprecated.
 	spider.cca removed.
 
 	* Documentation: general cleanup in help files. New chapter on
 	t-values in cca/rda/capscale in vegan-FAQ. New pdf document on
-	partioning with varpart by Pierre Legendre & co. Non-latin
+	partitioning with varpart by Pierre Legendre & co. Non-latin
 	characters now use UTF-8 in documentation.  R manual says that you
 	should not use non-latin characters in help files, but that was
 	written by Englishmen. However, this seems to cause distress to
@@ -1645,7 +1645,7 @@ Version 1.6-9 (April 22, 2005)
 	missing values in row, column or matrix standardizations.
 
 	* vegdist: new argument na.rm (defaults FALSE) for pairwise
-	deletion of missing vaues in dissimilarity calculation.
+	deletion of missing values in dissimilarity calculation.
 		
 Version 1.6-8 (April 18, 2005)
 
@@ -1737,7 +1737,7 @@ Version 1.6-8 (April 18, 2005)
 	missing or all zeros). 
 
 	* spenvcor:  new function to find the "species -- environment
-	correlation" in contrained ordination (cca, rda, capscale).
+	correlation" in constrained ordination (cca, rda, capscale).
 
 	* stressplot: a new function to plot Shepard diagram for 'metaMDS'
 	or 'isoMDS'.
@@ -1770,8 +1770,8 @@ Version 1.6-7 (Jan 24, 2005)
 	* new diagnostic and helper functions for 'cca', 'rda' and
 	'capscale': 'goodness' to estimate the proportion of inertia
 	accounted for or residuals for sites or species; 'inertcomp' to
-	decompose species and site inertia for conditioned, contrained and
-	residual componets; 'vif.cca' to estimate the variance inflation
+	decompose species and site inertia for conditioned, constrained and
+	residual components; 'vif.cca' to estimate the variance inflation
 	factors for constraints and conditions; 'fitted' and 'residuals'
 	to approximate data by ordination scores; 'predict' to approximate
 	data or find site or species scores, possibly with 'newdata';
@@ -1809,7 +1809,7 @@ Version 1.6-5 (Oct 12, 2004)
 	* Based on version 1.7-27. Checked with R-1.9.1 (Linux, MacOS X)
 	and R-2.0.0 (Linux, patched version in Windows XP). Passed other
 	tests, but some examples in 'humpfit' failed in Windows XP, and
-	are not run on that platfrom. General cleanup in documentation.
+	are not run on that platform. General cleanup in documentation.
 	Does not 'require(mva)' any longer.
 
 	* anosim: corrected the equation in docs (function was
@@ -1905,7 +1905,7 @@ Version 1.6-4 (June 10, 2004)
 	arrows, and they are now longer in general. Axes are drawn for
 	biplot arrows also with `text.cca' and `points.cca' functions.
 
-	* deviance.cca and extractAIC.cca: auxilliary functions which
+	* deviance.cca and extractAIC.cca: auxiliary functions which
 	allow automatic model building with `step' or `stepAIC' (MASS)
 	functions in cca and rda. Unfortunately, cca and rda do not have
 	deviance or AIC, and these functions are certainly wrong and
@@ -1929,7 +1929,7 @@ Version 1.6-3 (Mar 22, 2004)
 	* vegan-FAQ: Does not show the vegan and R versions the
 	documentations were built, because of stupid incompatible change
 	in R-1.9.0 of the future.  package.description() function was
-	unnecessarily replaced with packageDescription, and to accomodate
+	unnecessarily replaced with packageDescription, and to accommodate
 	recent, present and future versions of R seemed to be too much
 	hassle.
  
@@ -2012,7 +2012,7 @@ Version 1.6-0 (Fisher)
 
 	* rarefy: Can now optionally find SE of rarefied richness.
 
-	* renyi: A new function to find Rényi diversities or Hill numbers
+	* renyi: A new function to find Rï¿½nyi diversities or Hill numbers
 	with any scale (thanks to Roeland Kindt).
 
 	* scores.ordiplot: should be more robust now.
@@ -2050,7 +2050,7 @@ Version 1.4-4
 	* downweight: passes the downweighting fraction as an attribute,
 	and decorana catches and prints the fraction.
 
-	* wascores: Uses now biased variances for expading WAs and returns
+	* wascores: Uses now biased variances for expanding WAs and returns
 	the shrinkage factors as an attribute "shrinkage".  Shrinkage
 	factors are equal to eigenvalues in CCA when only this one
 	variable is used as constraint. Function `eigengrad' returns only
@@ -2198,7 +2198,7 @@ Other changes:
 	* cca.default(): Handles now NULL matrices X and Z: skips them.
 
 	* cca.formula(): Knows now cca(X ~ 1) and permforms unconstrained
-	CA, and cca(X ~ ., data) and perfors CCA using all variables in
+	CA, and cca(X ~ ., data) and performs CCA using all variables in
 	`data' as constraints. Has now na.action=na.fail so that cca
 	crashes more informatively (used to crash mysteriously). A more
 	graceful na.action may come. Assignment "=" corrected to the true

--- a/man/adipart.Rd
+++ b/man/adipart.Rd
@@ -43,7 +43,7 @@ hiersimu(...)
     species as column. Right hand side (\code{x}) must be grouping variables
     referring to levels of sampling hierarchy, terms from right to left
     will be treated as nested (first column is the lowest, last is the
-    highest level). The formula will add a unique indentifier to rows and
+    highest level). The formula will add a unique identifier to rows and
     constant for the rows to always produce estimates of row-level alpha
     and overall gamma diversities. You must use non-formula
     interface to avoid this behaviour. Interaction terms are

--- a/man/betadisper.Rd
+++ b/man/betadisper.Rd
@@ -114,7 +114,7 @@ betadistances(x, \dots)
     family-wise confidence level to use.}
   \item{digits, neigen}{numeric; for the \code{print} method, sets the
   number of digits to use (as per \code{\link{print.default}}) and the
-  maximum number of axes to display eigenvalues for, repsectively.}
+  maximum number of axes to display eigenvalues for, respectively.}
   \item{\dots}{arguments, including graphical parameters (for
     \code{plot.betadisper} and \code{boxplot.betadisper}), passed to
     other methods.}

--- a/man/diversity.Rd
+++ b/man/diversity.Rd
@@ -54,7 +54,7 @@ specnumber(x, groups, MARGIN = 1)
   diversity can be found as the mean of diversities by the same groups,
   and their difference or ratio is an estimate of beta diversity (see
   Examples). The pooling can be based either on the observed
-  abundancies, or all communities can be equalized to unit total before
+  abundances, or all communities can be equalized to unit total before
   pooling; see Jost (2007) for discussion. Functions
   \code{\link{adipart}} and \code{\link{multipart}} provide canned
   alternatives for estimating alpha, beta and gamma diversities in

--- a/man/make.cepnames.Rd
+++ b/man/make.cepnames.Rd
@@ -44,7 +44,7 @@ make.cepnames(names, minlengths = c(4,4), seconditem = FALSE,
   CEP names as default, but it can also use other lengths. The function
   is based on \code{\link{abbreviate}} and can produce longer names if
   basic names are not unique. If generic name is shorter than specified
-  minimun length, more characters can be used by the epithet. If
+  minimum length, more characters can be used by the epithet. If
   \code{uniqgenera = TRUE} genus can use more characters, and these
   reduce the number of characters available for the epithet. The
   function drops characters from the end, but with \code{method =

--- a/man/metaMDS.Rd
+++ b/man/metaMDS.Rd
@@ -193,7 +193,7 @@ metaMDSredist(object, ...)
     \code{autotransform = FALSE} and standardize and transform data
     independently. The \code{autotransform} is intended for community
     data, and for other data types, you should set
-    \code{autotransform = FALSE}. This step is perfomed using
+    \code{autotransform = FALSE}. This step is performed using
     \code{metaMDSdist}, and the step is skipped if input were
     dissimilarities.
 

--- a/man/monoMDS.Rd
+++ b/man/monoMDS.Rd
@@ -110,7 +110,7 @@ monoMDS(dist, y, k = 2, model = c("global", "local", "linear", "hybrid"),
     and dissimilarities are tied to their maximum value of one. Breaking
     ties allows these points to be at different distances and can help
     in recovering very long coenoclines (gradients).  Functions in the
-    \CRANpkg{smacof} package also hav adequate tie treatment.
+    \CRANpkg{smacof} package also have adequate tie treatment.
 
     \item Handles missing values in a meaningful way.
 

--- a/man/multipart.Rd
+++ b/man/multipart.Rd
@@ -31,7 +31,7 @@ multipart(...)
     variable(s) referring to levels of sampling hierarchy, terms from
     right to left will be treated as nested (first column is the lowest,
     last is the highest level). The formula will add a unique
-    indentifier to rows and constant for the rows to always produce
+    identifier to rows and constant for the rows to always produce
     estimates of row-level alpha and overall gamma diversities. You must
     use non-formula interface to avoid this behaviour. Interaction terms
     are not allowed.}

--- a/man/ordiArrowTextXY.Rd
+++ b/man/ordiArrowTextXY.Rd
@@ -66,7 +66,7 @@ ordiArrowMul(x, at = c(0,0), fill = 0.75, display, choices = c(1,2), \ldots)
   \code{ordiArrowTextXY} does not draw labels; it simply returns
   coordinates at which the labels should be drawn for use with another
   function, such as \code{\link{text}}. The arrow will point to the
-  midpoint of the text bouding box. Several ordination \code{plot} and
+  midpoint of the text bounding box. Several ordination \code{plot} and
   \code{text} functions have argument \code{optimize} which will
   override this location. }
 

--- a/man/ordiplot.Rd
+++ b/man/ordiplot.Rd
@@ -59,7 +59,7 @@ ordiplot(ord, choices = c(1, 2), type="points", display, optimize = FALSE,
     arrows for species. The arrow head will be at the value of scores,
     and possible text is moved outwards.}
   \item{length}{Length of arrow heads (see \code{\link{arrows}}).}
-  \item{arr.mul}{Numeric multiplier to arrow lenghts; this will also set
+  \item{arr.mul}{Numeric multiplier to arrow lengths; this will also set
     \code{arrows = TRUE}. The default is to automatically adjust arrow
     lengths with \code{"biplot"} and \code{"regression"} scores and else
     use unmodified scores.}

--- a/man/plot.cca.Rd
+++ b/man/plot.cca.Rd
@@ -153,7 +153,7 @@
   \code{sit.par} etc.) which take precedence over global parameters and
   defaults. This allows full control of graphics. The scores are plotted
   with \code{\link{text.ordiplot}} and \code{\link{points.ordiplot}} and
-  accept paremeters of these functions. In addition to standard
+  accept parameters of these functions. In addition to standard
   graphical parameters, text can be plotted over non-transparent label
   with arbument \code{bg = <colour>}, and location of text can be
   optimized to avoid over-writing with argument \code{optimize = TRUE},

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -88,7 +88,7 @@ showvarparts(parts, labels, bg = NULL, alpha = 63, Xnames,
 
 \item{permutations}{If \code{chisquare = TRUE}, the adjusted
     \eqn{R^2}{R-squared} is estimated by permutations, and this
-    paramater can be a list of control values for the permutations as
+    parameter can be a list of control values for the permutations as
     returned by the function \code{\link[permute]{how}}, or the number
     of permutations required, or a permutation matrix where each row
     gives the permuted indices.}
@@ -314,7 +314,7 @@ Montreal, Canada.  Further developed by Jari Oksanen. }
   or Cailliez adjustment, which in effect add random variation to the
   dissimilarities.
 
-  A simplified, fast version of RDA, CCA adn dbRDA are used (functions
+  A simplified, fast version of RDA, CCA ann dbRDA are used (functions
   \code{simpleRDA2}, \code{simpleCCA} and \code{simpleDBRDA}).  The
   actual calculations are done in functions \code{varpart2} to
   \code{varpart4}, but these are not intended to be called directly by

--- a/man/varpart.Rd
+++ b/man/varpart.Rd
@@ -314,7 +314,7 @@ Montreal, Canada.  Further developed by Jari Oksanen. }
   or Cailliez adjustment, which in effect add random variation to the
   dissimilarities.
 
-  A simplified, fast version of RDA, CCA ann dbRDA are used (functions
+  A simplified, fast version of RDA, CCA and dbRDA are used (functions
   \code{simpleRDA2}, \code{simpleCCA} and \code{simpleDBRDA}).  The
   actual calculations are done in functions \code{varpart2} to
   \code{varpart4}, but these are not intended to be called directly by

--- a/man/vegan-package.Rd
+++ b/man/vegan-package.Rd
@@ -72,7 +72,7 @@ anova(mod)
 ## is added to the model after all other terms
 anova(mod, by = "margin")
 ## Plot only sample plots, use different symbols and draw SD ellipses 
-## for Managemenet classes
+## for Management classes
 plot(mod, display = "sites", type = "n")
 with(dune.env, points(mod, disp = "si", pch = as.numeric(Management)))
 with(dune.env, legend("topleft", levels(Management), pch = 1:4,

--- a/man/wascores.Rd
+++ b/man/wascores.Rd
@@ -68,7 +68,7 @@ eigengrad(x, w)
   \code{\link{diversity}}). The numeric results can be accessed with
   \code{scores} function.  Function \code{\link{tolerance}} uses the
   same algebra for weighted standard deviation, but bases the variance
-  on linear combination scores (constaints) variables instead of the
+  on linear combination scores (constraints) variables instead of the
   weighted averages of the sites like \code{wascores}.
 
   Weighted averages are closely linked to correspondence analysis

--- a/src/decorana.f
+++ b/src/decorana.f
@@ -147,7 +147,7 @@ c     for the blocks of 3.
       end
 
 c Function segfit is identical to detrnd, but it also returns the fitted
-c values z. x is respone in input, and residuals in output. --Added by
+c values z. x is response in input, and residuals in output. --Added by
 c J. Oksanen 1 Oct, 2010.
       subroutine segfit(x,aidot,ix,mi,mk,fit)
       implicit double precision (a-h,o-z)

--- a/src/goffactor.c
+++ b/src/goffactor.c
@@ -1,5 +1,5 @@
 /* Helper functions used in envfit for assessing goodness of fit in
- * permuation tests. The functions are really minimal, but they are
+ * permutation tests. The functions are really minimal, but they are
  * the bottlenecks that need be hidden in C code. 
  */
 

--- a/src/monoMDS.f
+++ b/src/monoMDS.f
@@ -28,7 +28,7 @@ C            Edwardsville, IL 62026-1651, U.S.A.
 C            Phone: +1-618-650-2975   FAX: +1-618-650-3174
 C            Email: pminchi@siue.edu
 C
-C Starting from a supplied initial configuarion, uses steepest descent
+C Starting from a supplied initial configuration, uses steepest descent
 C   to minimize Kruskal's stress, a measure of badness-of-fit of one
 C   or more regressions of distances onto the supplied dissimilarities.
 C
@@ -195,7 +195,7 @@ C COPY INITIAL CONFIGURATION TO CURRENT CONFIGURATION
 C
       CALL MACOPY (XINIT,NOBJ,NOBJ,NDIM,X,NOBJ)
 C
-C INITALIZE GRADIENT (WILL BE USED AS THE FIRST "LAST GRADIENT")
+C INITIALIZE GRADIENT (WILL BE USED AS THE FIRST "LAST GRADIENT")
 C
       CALL MAINIT (GRAD,NOBJ,NDIM,NOBJ,SQRT(1.0/FNDIM))
 C=======================================================================
@@ -817,7 +817,7 @@ C---NTIE is the number of DISS values in the current group of tied values
 C---Primary tie treatment: sort DIST values within this tied group into
 C     ascending order, permuting the index vectors accordingly.
 C     Initialize fitted values, DHAT, to be equal to DIST and make each
-C     value an intial block of size 1.
+C     value an initial block of size 1.
               CALL ASORT4 (DIST(J+1),NTIE,IIDX(J+1),JIDX(J+1))
               DO K=J+1,I
                 DHAT(K)=DIST(K)
@@ -861,7 +861,7 @@ C-----------------------------------------------------------------------
       ICURR=1
 C-----------------------------------------------------------------------
 C START OF PROCEDURE FOR THE CURRENT BLOCK.  IT IS INITIALLY UP-ACTIVE,
-C   AND NEITHER UP- NOR DOWN-SATISIFIED.
+C   AND NEITHER UP- NOR DOWN-SATISFIED.
 C
 C UP-ACTIVE  (IACTIV=1) means we are comparing DHAT for the current
 C   block with DHAT for blocks to its right.
@@ -884,11 +884,11 @@ C---Compute DHAT for the current block
       DHATAV=DHAT(ICURR)/IWORK(ICURR)
 C-----------------------------------------------------------------------
 C   ACCORDING TO CURRENT ACTIVITY, CHECK WHETHER CURRENT BLOCK IS
-C     UP-SATISFIED (IACTIV=1) OR DOWN-SATISIFED (IACTIV=0)
+C     UP-SATISFIED (IACTIV=1) OR DOWN-SATISFIED (IACTIV=0)
 C-----------------------------------------------------------------------
    30 IF (IACTIV.EQ.0) THEN
 C-----------------------------------------------------------------------
-C     CHECK WHETHER THIS BLOCK IS DOWN-SATISIFIED.  IF NOT, MERGE.
+C     CHECK WHETHER THIS BLOCK IS DOWN-SATISFIED.  IF NOT, MERGE.
 C-----------------------------------------------------------------------
         IF (ICURR.EQ.1) THEN
 C---If it's the first block, it is by definition down-satisfied
@@ -911,12 +911,12 @@ C   its left and make the new merged block the current block
         ENDIF
       ELSE
 C-----------------------------------------------------------------------
-C     CHECK WHETHER THIS BLOCK IS UP-SATISIFIED.  IF NOT, MERGE.
+C     CHECK WHETHER THIS BLOCK IS UP-SATISFIED.  IF NOT, MERGE.
 C-----------------------------------------------------------------------
 C---Index of first member of the block to the right
         INEXT=ICURR+IWORK(ICURR)
         IF (INEXT.GT.N) THEN
-C---If current block is last block, it is, by definition up-satisified
+C---If current block is last block, it is, by definition up-satisfied
           NSATIS=NSATIS+1
         ELSEIF (DHATAV.LT.DHAT(INEXT)/IWORK(INEXT)) THEN
 C---Current block is up-satisfied

--- a/src/nestedness.c
+++ b/src/nestedness.c
@@ -39,7 +39,7 @@
 /* R 3.4.0 provided an API to C function R_unif_index, and we now
  * depend on that version of R. An improved method of getting random
  * integer index was provided in R 3.6.0 and it is wise to upgrade to
- * that version of R (see R Bug Reprot PR#17494), but nestedness
+ * that version of R (see R Bug Report PR#17494), but nestedness
  * functions work also with older versions. Earlier we used
  * unif_rand() and changed that to an integer index, but R version
  * should be better. */
@@ -424,7 +424,7 @@ static void boostedqswap(int *m, int nr, int nc, int *work)
 /* greedy quasiswapping: pick >1 cell as the upper right m[a] element
  * (except when thinning). We collect a vector 'big' of indices of >1
  * cells, and after each quasiswap update its members and length. We
- * loop while 'big' has members. Each successfull quasiswap will
+ * loop while 'big' has members. Each successful quasiswap will
  * produce a 2x2 submatrix with fill 3 or 4, and the result is heavily
  * biased. With 'thin' we can mix ordinary quasiswap steps with greedy
  * steps and the bias is much reduced even with modest thinning, but
@@ -996,7 +996,7 @@ SEXP do_qswap(SEXP x, SEXP nsim, SEXP arg4, SEXP method)
     return x;
 }
 
-/* boosted quasiswap: x must be 3D array similary as in do_qswap (no
+/* boosted quasiswap: x must be 3D array similarly as in do_qswap (no
  * thin yet) */
 
 SEXP do_boostedqswap(SEXP x, SEXP nsim)

--- a/src/stepacross.c
+++ b/src/stepacross.c
@@ -125,7 +125,7 @@ void stepabyss(double *dist, int *n, double *toolong, int *val)
 	       visitabyss(k, ++id, val, *n, dist);
 }
 
-/* Function dykstrapath impelements Dijkstra's shortest path algorithm
+/* Function dykstrapath implements Dijkstra's shortest path algorithm
  * for graph traversal. Return matrix outval contains shortest path
  * distances.  Function matrixpfs() in Sedgewick, 1990, page 466
  * (priority first search for dense graphs).

--- a/src/vegdist.c
+++ b/src/vegdist.c
@@ -513,7 +513,7 @@ static double veg_mountford(double *x, int nr, int nc, int i1, int i2)
  * than the permutation procedure used in the original reference (Raup
  * & Crick 1979 Paleontology, as related by Legendre and Legendre in
  * Numerical Ecology), this function uses phyper() for a faster and
- * more precise calculcation.  I subsequently found that the same
+ * more precise calculation.  I subsequently found that the same
  * (obvious) idea is in the literature under a variety of other names
  * (or sometimes no name).
  *

--- a/tests/Examples/vegan-Ex.Rout.save
+++ b/tests/Examples/vegan-Ex.Rout.save
@@ -8712,7 +8712,7 @@ Residual   13   37.699
 ---
 Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
 > ## Plot only sample plots, use different symbols and draw SD ellipses 
-> ## for Managemenet classes
+> ## for Management classes
 > plot(mod, display = "sites", type = "n")
 > with(dune.env, points(mod, disp = "si", pch = as.numeric(Management)))
 > with(dune.env, legend("topleft", levels(Management), pch = 1:4,

--- a/tests/decostand-tests.R
+++ b/tests/decostand-tests.R
@@ -109,7 +109,7 @@ all(as.matrix(x1) == as.matrix(x2c))
 
 ############################# NAMES ####################################
 
-# Tests that dimensins have correct names
+# Tests that dimensions have correct names
 all(rownames(decostand(testdata + 1, method = "clr")) == rownames(testdata))
 all(colnames(decostand(testdata, method = "clr", pseudocount = 1)) == colnames(testdata))
 all(rownames(decostand(testdata, method = "rclr")) == rownames(testdata))

--- a/tests/decostand-tests.Rout.save
+++ b/tests/decostand-tests.Rout.save
@@ -839,7 +839,7 @@ col50 FALSE
 > 
 > ############################# NAMES ####################################
 > 
-> # Tests that dimensins have correct names
+> # Tests that dimensions have correct names
 > all(rownames(decostand(testdata + 1, method = "clr")) == rownames(testdata))
 [1] TRUE
 > all(colnames(decostand(testdata, method = "clr", pseudocount = 1)) == colnames(testdata))

--- a/tests/vegan-tests.R
+++ b/tests/vegan-tests.R
@@ -6,7 +6,7 @@
 ### must generate new vegan-tests.Rout.save in this directory.
 
 ### The current plan is that tests/ are not included in the CRAN
-### release, but only in the development versin of vegan in R-Forge.
+### release, but only in the development version of vegan in R-Forge.
 
 ### The tests here are not intended for human reading. The tests need
 ### not be ecological or biologically meaningful, but they are only
@@ -138,7 +138,7 @@ rm(X, A, B, C, cap.model.cond, cap.model, rda.model.cond, rda.model)
 ### failed if community data name was the same as a function name: the
 ### function name was found first, and used instead ofa data. This
 ### seems to be related to the same problem that Sven Neulinger
-### communicated, and his examples still faile if Condition or strata
+### communicated, and his examples still failed if Condition or strata
 ### are function names. However, the following examples that failed
 ### should work now:
 

--- a/tests/vegan-tests.Rout.save
+++ b/tests/vegan-tests.Rout.save
@@ -23,7 +23,7 @@ Type 'q()' to quit R.
 > ### must generate new vegan-tests.Rout.save in this directory.
 > 
 > ### The current plan is that tests/ are not included in the CRAN
-> ### release, but only in the development versin of vegan in R-Forge.
+> ### release, but only in the development version of vegan in R-Forge.
 > 
 > ### The tests here are not intended for human reading. The tests need
 > ### not be ecological or biologically meaningful, but they are only
@@ -642,7 +642,7 @@ Residual 26   5.2565
 > ### failed if community data name was the same as a function name: the
 > ### function name was found first, and used instead ofa data. This
 > ### seems to be related to the same problem that Sven Neulinger
-> ### communicated, and his examples still faile if Condition or strata
+> ### communicated, and his examples still failed if Condition or strata
 > ### are function names. However, the following examples that failed
 > ### should work now:
 > 

--- a/vignettes/FAQ-vegan.Rmd
+++ b/vignettes/FAQ-vegan.Rmd
@@ -227,7 +227,7 @@ because people use same names for different indices.
 ### I cannot get repeated solutions in `metaMDS`
 
 The first (try 0) run of `metaMDS` starts from the metric scaling
-solution and is usually good, and most sofware only return that
+solution and is usually good, and most software only return that
 solution. However, `metaMDS` tries to see if that standard solution
 can be repeated, or improved and the improved solution still
 repeated. In all cases, it will return the best solution found, and

--- a/vignettes/diversity-vegan.Rnw
+++ b/vignettes/diversity-vegan.Rnw
@@ -619,7 +619,7 @@ as we saw only once, and the idea in bootstrap that if we repeat
 sampling (with replacement) from the same data, we miss as many
 species as we missed originally.
 
-The variance estimaters only concern the estimated number of missing
+The variance estimators only concern the estimated number of missing
 species $\hat f_0$, although they are often expressed as they would
 apply to the pool size $S_p$; this is only true if we assume that
 $\VAR(S_o) = 0$.  The variance of the Chao estimate is \citep{ChiuEtal14}:


### PR DESCRIPTION
This PR fixes misspellings across this repository. Misspellings present in `.R`, `.Rd`, and `NEWS` files, not including variables, were fixed. There were some misspellings present in code messages and comments; to these I paid extra attention in fixing.

The misspellings were detected in this fashion:

> ...via the `typos` hook (<https://github.com/crate-ci/typos>) which can be used in concert with `pre-commit` (<https://github.com/pre-commit/pre-commit>) via `.pre-commit-config.yaml` and `_typos.toml` configuration files. 
>
> I dropped these two files into the repository and ran then via `pre-commit install` and then `pre-commit run --all-files` to find the misspellings and any false positives.

The `_typos.toml` configuration file I used:

```
[default.extend-words]
# false positives or items to ignore
indx = "indx"
Domin = "Domin"
alikes = "alikes"
decission = "decission"
fre = "fre"
strat = "strat"
triagle = "triagle"
sist = "sist"
hel = "hel"
Universite = "Universite"
Departement = "Departement"
Shepard = "Shepard"
ist = "ist"
numer = "numer"
Anull = "Anull"
gam = "gam"
WARNIN = "WARNIN"
groupes = "groupes"
nam = "nam"
Ser = "Ser"
edn = "edn"
nams = "nams"
sammon = "sammon"
thm = "thm"
Gir = "Gir"
regon = "regon"
Commun = "Commun"
clen = "clen"
pn = "pn"
ba = "ba"
Comput = "Comput"
fnd = "fnd"
parm = "parm"
Lik = "Lik"
leve = "leve"
oints = "oints"

[files]
extend-exclude = [
]
```

The items that were detected but that I did not fix (since I wasn't sure what the correct would be or since the fixing would be a breaking change) (perhaps @jarioksa or @gavinsimpson can review):

<details markdown=1>

<summary> Detected But Un-Fixed Items </summary>

```
error: `wih` should be `with`
  ╭▸ R/read.cep.R:9:59
  │
9 │ ### fail, and read.fortran() can also fail, in particular wih
  ╰╴                                                          ━━━
error: `weigth` should be `weight`
   ╭▸ man/wcmdscale.Rd:50:20
   │
50 │     variable \code{weigth}, and names in variable \code{label}.}
   ╰╴                   ━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:154:8
    │
154 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:159:6
    │
159 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:427:8
    │
427 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:431:6
    │
431 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:434:8
    │
434 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:438:6
    │
438 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:626:8
    │
626 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:630:6
    │
630 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:634:11
    │
634 │ %% \begin{multline}
    ╰╴          ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:638:9
    │
638 │ %% \end{multline}
    ╰╴        ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:641:8
    │
641 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:645:6
    │
645 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:658:8
    │
658 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:662:6
    │
662 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:704:8
    │
704 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:708:6
    │
708 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:712:8
    │
712 │ \begin{multline}
    ╰╴       ━━━━━━━━
error: `multline` should be `multiline`
    ╭▸ vignettes/diversity-vegan.Rnw:717:6
    │
717 │ \end{multline}
    ╰╴     ━━━━━━━━
error: `STRINC` should be `STRING`
    ╭▸ src/monoMDS.f:151:9
    │
151 │      .  STRINC, COSAV, ACOSAV, SRATAV, STEP, FNDIM, SFGR, SRATIO,
    ╰╴        ━━━━━━
error: `STRINC` should be `STRING`
    ╭▸ src/monoMDS.f:165:7
    │
165 │       STRINC=1.1
    ╰╴      ━━━━━━
error: `STRINC` should be `STRING`
    ╭▸ src/monoMDS.f:306:24
    │
306 │         IF ((SRATIO.GT.STRINC.OR.CAGRGL.LT.(-0.95)).AND.NBACK.LT.3)
    ╰╴                       ━━━━━━
error: `RECIPT` should be `RECEIPT`, `RECIPE`
    ╭▸ src/monoMDS.f:521:57
    │
521 │      .  DHAT(NDIS), STRESS, SFACT, TFACT, DMEAN, SOTSQ, RECIPT,
    ╰╴                                                        ━━━━━━
error: `RECIPT` should be `RECEIPT`, `RECIPE`
    ╭▸ src/monoMDS.f:526:7
    │
526 │       RECIPT=1.0/TFACT
    ╰╴      ━━━━━━
error: `RECIPT` should be `RECEIPT`, `RECIPE`
    ╭▸ src/monoMDS.f:532:28
    │
532 │               DELTA=(SOTSQ-RECIPT*(DIST(K)-DHAT(K))/DIST(K))*
    ╰╴                           ━━━━━━
error: `RECIPT` should be `RECEIPT`, `RECIPE`
    ╭▸ src/monoMDS.f:543:17
    │
543 │      .          RECIPT*(DIST(K)-DHAT(K))/DIST(K))*
    ╰╴                ━━━━━━
error: `orded` should be `ordered`
   ╭▸ man/vegemite.Rd:45:24
   │
45 │     Dendrograms are re-orded by the first axis of correspondence
   ╰╴                       ━━━━━
error: `constrasts` should be `contrasts`
   ╭▸ R/simper.R:46:30
   │
46 │         ## function to match constrasts
   ╰╴                             ━━━━━━━━━━
```

</details>