### PR TITLE
summary.isomap: drop reference to undefined 'axes'

### DIFF
--- a/R/summary.isomap.R
+++ b/R/summary.isomap.R
@@ -1,7 +1,6 @@
 `summary.isomap` <-
 function (object, ...)
 {
-	axes <- min(axes, ncol(object$points))
 	out <- list()
 	out$call <- object$call
 	out$net <- object$net

--- a/tests/vegan-tests.R
+++ b/tests/vegan-tests.R
@@ -287,3 +287,12 @@ ev <- summary(eigenvals(mod))
 stopifnot(inherits(ev, "matrix"))
 stopifnot(!is.list(ev))
 ev
+
+### summary.isomap
+data(dune)
+ord <- isomap(vegdist(dune), k = 3)
+summ <- summary(ord)
+stopifnot(inherits(summ, "summary.isomap"))
+stopifnot(summ$nnet == nrow(ord$net))
+stopifnot(summ$ndis == nrow(dune) * (nrow(dune) - 1) / 2)
+rm(ord, summ)

--- a/tests/vegan-tests.Rout.save
+++ b/tests/vegan-tests.Rout.save
@@ -1038,6 +1038,14 @@ Eigenvalue            0.0018068 0.0009945
 Proportion Explained  0.0009326 0.0005133
 Cumulative Proportion 0.9994867 1.0000000
 > 
+> ### summary.isomap
+> data(dune)
+> ord <- isomap(vegdist(dune), k = 3)
+> summ <- summary(ord)
+> stopifnot(inherits(summ, "summary.isomap"))
+> stopifnot(summ$nnet == nrow(ord$net))
+> stopifnot(summ$ndis == nrow(dune) * (nrow(dune) - 1) / 2)
+> rm(ord, summ)
 > proc.time()
    user  system elapsed 
   1.229   0.055   1.284 


### PR DESCRIPTION
summary() on an isomap result aborted because the method evaluated `axes <- min(axes, ncol(object$points))`, although `axes` is neither a formal argument nor defined earlier in the body.

The computed value was never used. Remove the dead assignment so the method can assemble and return the summary object.

Add a regression test that summarizes an isomap object and checks the returned class and component counts.

Found during my https://github.com/sims1253/ry audit